### PR TITLE
Fix Rust crate name reference in main.rs

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -2,5 +2,5 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
 fn main() {
-    claude_mcp_manager::run()
+    claude_code_tool_manager::run()
 }


### PR DESCRIPTION
## Summary
- Fix the Rust crate reference in `main.rs` from `claude_mcp_manager` to `claude_code_tool_manager`
- This was causing all CI builds to fail with: `use of unresolved module or unlinked crate`

## Test plan
- [x] CI build should now pass on all platforms

🤖 Generated with [Claude Code](https://claude.com/claude-code)