### PR TITLE
Fix global MCP config to write to ~/.claude.json

### DIFF
--- a/src-tauri/src/commands/config.rs
+++ b/src-tauri/src/commands/config.rs
@@ -158,6 +158,7 @@ pub fn get_claude_paths() -> Result<ClaudePaths, String> {
     let claude_paths = paths::get_claude_paths().map_err(|e| e.to_string())?;
     Ok(ClaudePaths {
         claude_dir: claude_paths.claude_dir.to_string_lossy().to_string(),
+        claude_json: claude_paths.claude_json.to_string_lossy().to_string(),
         global_settings: claude_paths.global_settings.to_string_lossy().to_string(),
         plugins_dir: claude_paths.plugins_dir.to_string_lossy().to_string(),
     })
@@ -200,6 +201,12 @@ pub fn backup_configs() -> Result<(), String> {
     let backup_name = format!("backup_{}", timestamp);
     let backup_path = backup_dir.join(&backup_name);
     std::fs::create_dir_all(&backup_path).map_err(|e| e.to_string())?;
+
+    // Copy claude.json if exists (main config with global MCPs)
+    if claude_paths.claude_json.exists() {
+        let dest = backup_path.join("claude.json");
+        std::fs::copy(&claude_paths.claude_json, dest).map_err(|e| e.to_string())?;
+    }
 
     // Copy settings.json if exists
     if claude_paths.global_settings.exists() {

--- a/src-tauri/src/db/models.rs
+++ b/src-tauri/src/db/models.rs
@@ -86,6 +86,7 @@ pub struct CreateProjectRequest {
 #[serde(rename_all = "camelCase")]
 pub struct ClaudePaths {
     pub claude_dir: String,
+    pub claude_json: String,  // ~/.claude.json - main config with global MCPs
     pub global_settings: String,
     pub plugins_dir: String,
 }

--- a/src-tauri/src/services/config_writer.rs
+++ b/src-tauri/src/services/config_writer.rs
@@ -80,9 +80,9 @@ pub fn write_project_config(project_path: &Path, mcps: &[McpTuple]) -> Result<()
 }
 
 pub fn write_global_config(paths: &ClaudePathsInternal, mcps: &[McpTuple]) -> Result<()> {
-    // Read existing settings.json or create new
-    let mut settings: Value = if paths.global_settings.exists() {
-        let content = std::fs::read_to_string(&paths.global_settings)?;
+    // Read existing ~/.claude.json or create new
+    let mut claude_json: Value = if paths.claude_json.exists() {
+        let content = std::fs::read_to_string(&paths.claude_json)?;
         serde_json::from_str(&content).unwrap_or(json!({}))
     } else {
         json!({})
@@ -91,12 +91,12 @@ pub fn write_global_config(paths: &ClaudePathsInternal, mcps: &[McpTuple]) -> Re
     // Build mcpServers object
     let mcp_config = generate_mcp_config(mcps);
     if let Some(servers) = mcp_config.get("mcpServers") {
-        settings["mcpServers"] = servers.clone();
+        claude_json["mcpServers"] = servers.clone();
     }
 
-    // Write back
-    let content = serde_json::to_string_pretty(&settings)?;
-    std::fs::write(&paths.global_settings, content)?;
+    // Write back to ~/.claude.json
+    let content = serde_json::to_string_pretty(&claude_json)?;
+    std::fs::write(&paths.claude_json, content)?;
 
     Ok(())
 }

--- a/src/routes/settings/+page.svelte
+++ b/src/routes/settings/+page.svelte
@@ -7,6 +7,7 @@
 
 	interface ClaudePaths {
 		claudeDir: string;
+		claudeJson: string;
 		globalSettings: string;
 		pluginsDir: string;
 	}
@@ -72,12 +73,12 @@
 					<div class="flex items-center gap-3">
 						<FileText class="w-5 h-5 text-gray-400" />
 						<div>
-							<p class="text-sm font-medium text-gray-900 dark:text-white">Global Settings</p>
-							<p class="text-xs text-gray-500 dark:text-gray-400 font-mono">{claudePaths.globalSettings}</p>
+							<p class="text-sm font-medium text-gray-900 dark:text-white">Global MCP Config</p>
+							<p class="text-xs text-gray-500 dark:text-gray-400 font-mono">{claudePaths.claudeJson}</p>
 						</div>
 					</div>
 					<button
-						onclick={() => openConfigFile(claudePaths!.globalSettings)}
+						onclick={() => openConfigFile(claudePaths!.claudeJson)}
 						class="btn btn-ghost text-xs"
 					>
 						Open


### PR DESCRIPTION
## Summary
- Global MCPs were incorrectly being written to `~/.claude/settings.json` instead of `~/.claude.json`
- Updated `write_global_config` to use the correct path (`paths.claude_json`)
- Added `claudeJson` field to the frontend interface to display the correct config path in settings

## Test plan
- [ ] Enable a global MCP and verify it appears in `~/.claude.json` under `mcpServers`
- [ ] Check settings page shows `~/.claude.json` as "Global MCP Config"
- [ ] Verify backup includes `claude.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)