### PR TITLE
Add Recently Updated sort option to MCP Marketplace

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-code-tool-manager",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Claude Code Tool Manager",
   "identifier": "com.claude-code-tool-manager.app",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "build": {
     "beforeDevCommand": "npm run dev",
     "devUrl": "http://localhost:5173",

--- a/src/lib/types/repo.ts
+++ b/src/lib/types/repo.ts
@@ -77,6 +77,7 @@ export interface RegistryMcpEntry {
 	sourceUrl?: string;
 	version?: string;
 	registryType?: string; // "npm", "pypi", etc.
+	updatedAt?: string; // ISO timestamp from registry
 }
 
 export interface EnvPlaceholder {


### PR DESCRIPTION
## Summary

- Add `updatedAt` field to `RegistryMcpEntry` for tracking update timestamps from the MCP registry API
- Add sort dropdown with "Recently Updated" (default) and "Name (A-Z)" options  
- Implement client-side sorting by `updatedAt` or name
- Remove debug logging from mcp_registry commands
- Bump version to 1.3.4

## Test plan

- [ ] Open Marketplace tab and verify MCPs load
- [ ] Verify default sort is "Recently Updated" 
- [ ] Switch to "Name (A-Z)" and verify alphabetical sorting
- [ ] Switch back to "Recently Updated" and verify date-based sorting

🤖 Generated with [Claude Code](https://claude.com/claude-code)