### PR TITLE
v1.3.8: Full SSE MCP Tool Listing Support

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-code-tool-manager",
-  "version": "1.3.7",
+  "version": "1.3.8",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -539,6 +539,7 @@ dependencies = [
  "directories",
  "env_logger",
  "fern",
+ "futures",
  "log",
  "pulldown-cmark",
  "regex",
@@ -556,6 +557,7 @@ dependencies = [
  "tauri-plugin-updater",
  "thiserror 2.0.17",
  "tokio",
+ "tokio-stream",
  "urlencoding",
  "walkdir",
 ]
@@ -1218,6 +1220,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1292,6 +1309,7 @@ version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
+ "futures-channel",
  "futures-core",
  "futures-io",
  "futures-macro",
@@ -4893,6 +4911,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
  "rustls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eca58d7bba4a75707817a2c44174253f9236b2d5fbd055602e9d5c07c139a047"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
  "tokio",
 ]
 

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "claude-code-tool-manager"
-version = "1.3.7"
+version = "1.3.8"
 description = "Desktop app to manage MCP servers, Skills, and Sub-Agents for Claude Code"
 authors = ["you"]
 edition = "2021"
@@ -42,8 +42,12 @@ rusqlite = { version = "0.37", features = ["bundled"] }
 # Time
 chrono = { version = "0.4", features = ["serde"] }
 
-# HTTP client for GitHub API
-reqwest = { version = "0.12", features = ["json", "rustls-tls", "blocking"] }
+# HTTP client for GitHub API and MCP testing
+reqwest = { version = "0.12", features = ["json", "rustls-tls", "blocking", "stream"] }
+
+# Async streaming utilities
+futures = "0.3"
+tokio-stream = "0.1"
 
 # Markdown parsing for README-based repos
 pulldown-cmark = "0.12"


### PR DESCRIPTION
## Summary

- Implement async streaming for SSE MCP testing to enable full tool listing
- Previously SSE only verified connectivity; now it lists all available tools like stdio and HTTP
- Add proper JSON parsing for SSE endpoint URLs
- Create dedicated tokio runtime for SSE tests

## Changes

- Add async SSE client using tokio runtime and reqwest streaming
- Parse SSE events to extract endpoint URL from `endpoint` event  
- Handle JSON-encoded endpoint URLs from SSE data field
- Send initialize/initialized/tools-list requests via POST to messages endpoint
- Read responses from SSE stream using mpsc channels
- Add `futures` and `tokio-stream` dependencies for async streaming

## Bug Fixes

- Fix URL parsing for SSE endpoint (handle JSON-encoded strings with quotes)
- Create dedicated tokio runtime for SSE tests (Tauri doesn't run in tokio context)

## Test plan

- [x] Test SSE MCP with local test server - all 8 tools listed correctly
- [x] Verify initialize → initialized → tools/list handshake completes
- [x] Confirm endpoint URL parsing works with JSON-encoded strings

🤖 Generated with [Claude Code](https://claude.com/claude-code)