### PR TITLE
Fix marketplace repo sync: auto-sync on add, better error feedback

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,25 @@ npm-debug.log*
 
 # Claude Code local settings (may contain tokens)
 .claude/
+.claude.json
+
+# MCP configuration (may contain API keys and tokens)
+.mcp.json
+
+# Secrets / credentials
+*.pem
+*.key
+*.p12
+*.pfx
+credentials.json
+secrets.json
+*secret*
+*token*
+!src/**/token*
+!src/**/secret*
+
+# Claude memory (personal notes)
+.claude_memory/
 
 # Playwright
 /test-results/

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,8 +1,0 @@
-{
-  "mcpServers": {
-    "Tool Manager MCP": {
-      "type": "http",
-      "url": "http://127.0.0.1:23847/mcp"
-    }
-  }
-}


### PR DESCRIPTION
## Summary
- **Auto-sync on add**: Newly added repositories are automatically synced immediately after creation, so users don't have to manually click the Sync button
- **Better error feedback**: Shows actionable warnings when sync finds 0 items (suggests changing repo type or content type) instead of a misleading "Added 0, updated 0 items" success message
- **Default repo type changed**: Default is now `file_based` instead of `readme_based`, since most repos contain actual .md files rather than awesome-list style README links
- **Security**: Added `.mcp.json` and other sensitive file patterns to `.gitignore`, removed `.mcp.json` from tracking

## Test plan
- [ ] Add a GitHub repository with .md files and verify it auto-syncs and loads items
- [ ] Add a repository that has no matching content and verify a warning is shown with guidance
- [ ] Verify the sync button on existing repos shows proper warnings/errors
- [ ] Verify the default repo type in the Add Repository modal is "File-based"