### PR TITLE
Add Spinner Verbs configuration GUI

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -587,7 +587,7 @@ dependencies = [
 
 [[package]]
 name = "claude-code-tool-manager"
-version = "2.1.4"
+version = "2.2.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -16,5 +16,6 @@ pub mod scanner;
 pub mod settings;
 pub mod skills;
 pub mod sounds;
+pub mod spinner_verbs;
 pub mod statusline;
 pub mod subagents;

--- a/src-tauri/src/commands/spinner_verbs.rs
+++ b/src-tauri/src/commands/spinner_verbs.rs
@@ -1,0 +1,237 @@
+use crate::db::{Database, SpinnerVerb};
+use crate::services::spinner_verb_writer;
+use log::info;
+use serde_json::Value;
+use std::sync::{Arc, Mutex};
+use tauri::State;
+
+/// Get all spinner verbs
+#[tauri::command]
+pub fn get_all_spinner_verbs(
+    db: State<'_, Arc<Mutex<Database>>>,
+) -> Result<Vec<SpinnerVerb>, String> {
+    info!("[SpinnerVerbs] Getting all spinner verbs");
+    let db = db.lock().map_err(|e| e.to_string())?;
+    get_all_spinner_verbs_from_db(&db)
+}
+
+/// Create a new spinner verb
+#[tauri::command]
+pub fn create_spinner_verb(
+    db: State<'_, Arc<Mutex<Database>>>,
+    verb: String,
+) -> Result<SpinnerVerb, String> {
+    info!("[SpinnerVerbs] Creating spinner verb: {}", verb);
+    let db = db.lock().map_err(|e| e.to_string())?;
+    create_spinner_verb_in_db(&db, &verb)
+}
+
+/// Update an existing spinner verb
+#[tauri::command]
+pub fn update_spinner_verb(
+    db: State<'_, Arc<Mutex<Database>>>,
+    id: i64,
+    verb: String,
+    is_enabled: bool,
+) -> Result<SpinnerVerb, String> {
+    info!("[SpinnerVerbs] Updating spinner verb id={}: {}", id, verb);
+    let db = db.lock().map_err(|e| e.to_string())?;
+    update_spinner_verb_in_db(&db, id, &verb, is_enabled)
+}
+
+/// Delete a spinner verb
+#[tauri::command]
+pub fn delete_spinner_verb(db: State<'_, Arc<Mutex<Database>>>, id: i64) -> Result<(), String> {
+    info!("[SpinnerVerbs] Deleting spinner verb id={}", id);
+    let db = db.lock().map_err(|e| e.to_string())?;
+    delete_spinner_verb_in_db(&db, id)
+}
+
+/// Reorder spinner verbs
+#[tauri::command]
+pub fn reorder_spinner_verbs(
+    db: State<'_, Arc<Mutex<Database>>>,
+    ids: Vec<i64>,
+) -> Result<(), String> {
+    info!("[SpinnerVerbs] Reordering {} spinner verbs", ids.len());
+    let db = db.lock().map_err(|e| e.to_string())?;
+    reorder_spinner_verbs_in_db(&db, &ids)
+}
+
+/// Get the spinner verb mode
+#[tauri::command]
+pub fn get_spinner_verb_mode(db: State<'_, Arc<Mutex<Database>>>) -> Result<String, String> {
+    let db = db.lock().map_err(|e| e.to_string())?;
+    get_spinner_verb_mode_from_db(&db)
+}
+
+/// Set the spinner verb mode
+#[tauri::command]
+pub fn set_spinner_verb_mode(
+    db: State<'_, Arc<Mutex<Database>>>,
+    mode: String,
+) -> Result<(), String> {
+    info!("[SpinnerVerbs] Setting mode to: {}", mode);
+    let db = db.lock().map_err(|e| e.to_string())?;
+    set_spinner_verb_mode_in_db(&db, &mode)
+}
+
+/// Sync spinner verbs to settings.json
+#[tauri::command]
+pub fn sync_spinner_verbs(db: State<'_, Arc<Mutex<Database>>>) -> Result<(), String> {
+    info!("[SpinnerVerbs] Syncing spinner verbs to settings.json");
+    let db = db.lock().map_err(|e| e.to_string())?;
+    sync_spinner_verbs_from_db(&db)
+}
+
+/// Read current spinner verbs config from settings.json
+#[tauri::command]
+pub fn read_current_spinner_verbs_config() -> Result<Option<Value>, String> {
+    info!("[SpinnerVerbs] Reading current config from settings.json");
+    spinner_verb_writer::read_current_spinner_verbs_config().map_err(|e| e.to_string())
+}
+
+// ============================================================================
+// Testable helper functions (no Tauri State dependency)
+// ============================================================================
+
+pub fn get_all_spinner_verbs_from_db(db: &Database) -> Result<Vec<SpinnerVerb>, String> {
+    db.get_all_spinner_verbs().map_err(|e| e.to_string())
+}
+
+pub fn create_spinner_verb_in_db(db: &Database, verb: &str) -> Result<SpinnerVerb, String> {
+    db.create_spinner_verb(verb).map_err(|e| e.to_string())
+}
+
+pub fn update_spinner_verb_in_db(
+    db: &Database,
+    id: i64,
+    verb: &str,
+    is_enabled: bool,
+) -> Result<SpinnerVerb, String> {
+    db.update_spinner_verb(id, verb, is_enabled)
+        .map_err(|e| e.to_string())
+}
+
+pub fn delete_spinner_verb_in_db(db: &Database, id: i64) -> Result<(), String> {
+    db.delete_spinner_verb(id).map_err(|e| e.to_string())
+}
+
+pub fn reorder_spinner_verbs_in_db(db: &Database, ids: &[i64]) -> Result<(), String> {
+    db.reorder_spinner_verbs(ids).map_err(|e| e.to_string())
+}
+
+pub fn get_spinner_verb_mode_from_db(db: &Database) -> Result<String, String> {
+    db.get_spinner_verb_mode().map_err(|e| e.to_string())
+}
+
+pub fn set_spinner_verb_mode_in_db(db: &Database, mode: &str) -> Result<(), String> {
+    db.set_spinner_verb_mode(mode).map_err(|e| e.to_string())
+}
+
+pub fn sync_spinner_verbs_from_db(db: &Database) -> Result<(), String> {
+    let verbs = db.get_all_spinner_verbs().map_err(|e| e.to_string())?;
+    let mode = db.get_spinner_verb_mode().map_err(|e| e.to_string())?;
+
+    let enabled_verbs: Vec<String> = verbs
+        .iter()
+        .filter(|v| v.is_enabled)
+        .map(|v| v.verb.clone())
+        .collect();
+
+    if enabled_verbs.is_empty() {
+        spinner_verb_writer::remove_spinner_verbs_from_settings().map_err(|e| e.to_string())
+    } else {
+        spinner_verb_writer::write_spinner_verbs_to_settings(&mode, &enabled_verbs)
+            .map_err(|e| e.to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn create_test_verb(db: &Database, verb: &str) -> SpinnerVerb {
+        create_spinner_verb_in_db(db, verb).unwrap()
+    }
+
+    #[test]
+    fn test_create_spinner_verb() {
+        let db = Database::in_memory().unwrap();
+        let verb = create_test_verb(&db, "Pondering");
+
+        assert_eq!(verb.verb, "Pondering");
+        assert!(verb.is_enabled);
+        assert_eq!(verb.display_order, 0);
+    }
+
+    #[test]
+    fn test_get_all_spinner_verbs() {
+        let db = Database::in_memory().unwrap();
+        create_test_verb(&db, "Pondering");
+        create_test_verb(&db, "Crafting");
+
+        let verbs = get_all_spinner_verbs_from_db(&db).unwrap();
+        assert_eq!(verbs.len(), 2);
+    }
+
+    #[test]
+    fn test_update_spinner_verb() {
+        let db = Database::in_memory().unwrap();
+        let verb = create_test_verb(&db, "Pondering");
+
+        let updated = update_spinner_verb_in_db(&db, verb.id, "Thinking", false).unwrap();
+        assert_eq!(updated.verb, "Thinking");
+        assert!(!updated.is_enabled);
+    }
+
+    #[test]
+    fn test_delete_spinner_verb() {
+        let db = Database::in_memory().unwrap();
+        let verb = create_test_verb(&db, "Pondering");
+        delete_spinner_verb_in_db(&db, verb.id).unwrap();
+
+        let verbs = get_all_spinner_verbs_from_db(&db).unwrap();
+        assert!(verbs.is_empty());
+    }
+
+    #[test]
+    fn test_spinner_verb_mode() {
+        let db = Database::in_memory().unwrap();
+
+        let mode = get_spinner_verb_mode_from_db(&db).unwrap();
+        assert_eq!(mode, "append");
+
+        set_spinner_verb_mode_in_db(&db, "replace").unwrap();
+        let mode = get_spinner_verb_mode_from_db(&db).unwrap();
+        assert_eq!(mode, "replace");
+    }
+
+    #[test]
+    fn test_reorder_spinner_verbs() {
+        let db = Database::in_memory().unwrap();
+        let v1 = create_test_verb(&db, "Pondering");
+        let v2 = create_test_verb(&db, "Crafting");
+        let v3 = create_test_verb(&db, "Brewing");
+
+        // Reorder: v3, v1, v2
+        reorder_spinner_verbs_in_db(&db, &[v3.id, v1.id, v2.id]).unwrap();
+
+        let verbs = get_all_spinner_verbs_from_db(&db).unwrap();
+        assert_eq!(verbs[0].verb, "Brewing");
+        assert_eq!(verbs[1].verb, "Pondering");
+        assert_eq!(verbs[2].verb, "Crafting");
+    }
+
+    #[test]
+    fn test_display_order_auto_increments() {
+        let db = Database::in_memory().unwrap();
+        let v1 = create_test_verb(&db, "Pondering");
+        let v2 = create_test_verb(&db, "Crafting");
+        let v3 = create_test_verb(&db, "Brewing");
+
+        assert_eq!(v1.display_order, 0);
+        assert_eq!(v2.display_order, 1);
+        assert_eq!(v3.display_order, 2);
+    }
+}

--- a/src-tauri/src/db/models.rs
+++ b/src-tauri/src/db/models.rs
@@ -642,6 +642,25 @@ pub struct StatusLineGalleryEntry {
     pub preview_text: Option<String>,
 }
 
+// Spinner Verbs
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SpinnerVerb {
+    pub id: i64,
+    pub verb: String,
+    pub is_enabled: bool,
+    pub display_order: i32,
+    pub created_at: String,
+    pub updated_at: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SpinnerVerbConfig {
+    pub mode: String, // "append" or "replace"
+    pub verbs: Vec<SpinnerVerb>,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -369,6 +369,16 @@ pub fn run() {
             commands::statusline::set_statusline_gallery_url,
             commands::statusline::generate_statusline_preview,
             commands::statusline::read_current_statusline_config,
+            // Spinner Verb Commands
+            commands::spinner_verbs::get_all_spinner_verbs,
+            commands::spinner_verbs::create_spinner_verb,
+            commands::spinner_verbs::update_spinner_verb,
+            commands::spinner_verbs::delete_spinner_verb,
+            commands::spinner_verbs::reorder_spinner_verbs,
+            commands::spinner_verbs::get_spinner_verb_mode,
+            commands::spinner_verbs::set_spinner_verb_mode,
+            commands::spinner_verbs::sync_spinner_verbs,
+            commands::spinner_verbs::read_current_spinner_verbs_config,
             // Debug Commands
             commands::debug::enable_debug_mode,
             commands::debug::disable_debug_mode,

--- a/src-tauri/src/services/mod.rs
+++ b/src-tauri/src/services/mod.rs
@@ -18,6 +18,7 @@ pub mod repo_sync;
 pub mod scanner;
 pub mod skill_writer;
 pub mod sound_player;
+pub mod spinner_verb_writer;
 pub mod statusline_gallery;
 pub mod statusline_writer;
 pub mod subagent_writer;

--- a/src-tauri/src/services/spinner_verb_writer.rs
+++ b/src-tauri/src/services/spinner_verb_writer.rs
@@ -1,0 +1,127 @@
+use anyhow::Result;
+use directories::BaseDirs;
+use serde_json::{json, Value};
+use std::path::Path;
+
+/// Read an existing settings.json file or return an empty object
+fn read_settings_file(path: &Path) -> Result<Value> {
+    if path.exists() {
+        let content = std::fs::read_to_string(path)?;
+        Ok(serde_json::from_str(&content).unwrap_or(json!({})))
+    } else {
+        Ok(json!({}))
+    }
+}
+
+/// Write settings.json file, preserving other settings
+fn write_settings_file(path: &Path, settings: &Value) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let content = serde_json::to_string_pretty(settings)?;
+    std::fs::write(path, content)?;
+    Ok(())
+}
+
+/// Write the spinnerVerbs key to ~/.claude/settings.json
+pub fn write_spinner_verbs_to_settings(mode: &str, verbs: &[String]) -> Result<()> {
+    let base_dirs =
+        BaseDirs::new().ok_or_else(|| anyhow::anyhow!("Could not find home directory"))?;
+    let home = base_dirs.home_dir();
+    let settings_path = home.join(".claude").join("settings.json");
+
+    let mut settings = read_settings_file(&settings_path)?;
+
+    let mut sv_config = serde_json::Map::new();
+    sv_config.insert("mode".to_string(), json!(mode));
+    sv_config.insert("verbs".to_string(), json!(verbs));
+
+    settings["spinnerVerbs"] = Value::Object(sv_config);
+
+    write_settings_file(&settings_path, &settings)
+}
+
+/// Remove the spinnerVerbs key from ~/.claude/settings.json
+pub fn remove_spinner_verbs_from_settings() -> Result<()> {
+    let base_dirs =
+        BaseDirs::new().ok_or_else(|| anyhow::anyhow!("Could not find home directory"))?;
+    let home = base_dirs.home_dir();
+    let settings_path = home.join(".claude").join("settings.json");
+
+    let mut settings = read_settings_file(&settings_path)?;
+
+    if let Some(obj) = settings.as_object_mut() {
+        obj.remove("spinnerVerbs");
+    }
+
+    write_settings_file(&settings_path, &settings)
+}
+
+/// Read the current spinnerVerbs config from ~/.claude/settings.json
+pub fn read_current_spinner_verbs_config() -> Result<Option<Value>> {
+    let base_dirs =
+        BaseDirs::new().ok_or_else(|| anyhow::anyhow!("Could not find home directory"))?;
+    let home = base_dirs.home_dir();
+    let settings_path = home.join(".claude").join("settings.json");
+
+    let settings = read_settings_file(&settings_path)?;
+    Ok(settings.get("spinnerVerbs").cloned())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    fn write_spinner_verbs_to_path(
+        settings_path: &Path,
+        mode: &str,
+        verbs: &[String],
+    ) -> Result<()> {
+        let mut settings = read_settings_file(settings_path)?;
+        let mut sv_config = serde_json::Map::new();
+        sv_config.insert("mode".to_string(), json!(mode));
+        sv_config.insert("verbs".to_string(), json!(verbs));
+        settings["spinnerVerbs"] = Value::Object(sv_config);
+        write_settings_file(settings_path, &settings)
+    }
+
+    #[test]
+    fn test_write_spinner_verbs_creates_config() {
+        let dir = TempDir::new().unwrap();
+        let settings_path = dir.path().join("settings.json");
+
+        let verbs = vec!["Pondering".to_string(), "Crafting".to_string()];
+        write_spinner_verbs_to_path(&settings_path, "append", &verbs).unwrap();
+
+        let content = fs::read_to_string(&settings_path).unwrap();
+        let settings: Value = serde_json::from_str(&content).unwrap();
+
+        assert_eq!(settings["spinnerVerbs"]["mode"], "append");
+        assert_eq!(settings["spinnerVerbs"]["verbs"][0], "Pondering");
+        assert_eq!(settings["spinnerVerbs"]["verbs"][1], "Crafting");
+    }
+
+    #[test]
+    fn test_write_preserves_other_settings() {
+        let dir = TempDir::new().unwrap();
+        let settings_path = dir.path().join("settings.json");
+
+        // Write initial settings
+        let initial = json!({"statusLine": {"type": "command"}});
+        write_settings_file(&settings_path, &initial).unwrap();
+
+        // Write spinner verbs
+        let verbs = vec!["Brewing".to_string()];
+        write_spinner_verbs_to_path(&settings_path, "replace", &verbs).unwrap();
+
+        let content = fs::read_to_string(&settings_path).unwrap();
+        let settings: Value = serde_json::from_str(&content).unwrap();
+
+        // Both keys should exist
+        assert!(settings.get("statusLine").is_some());
+        assert!(settings.get("spinnerVerbs").is_some());
+        assert_eq!(settings["spinnerVerbs"]["mode"], "replace");
+    }
+}

--- a/src/lib/components/layout/Sidebar.svelte
+++ b/src/lib/components/layout/Sidebar.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { page } from '$app/stores';
-	import { Library, FolderOpen, Settings, Plug, FileCode, Bot, Store, Zap, Terminal, Sparkles, Layers, PanelBottom } from 'lucide-svelte';
+	import { Library, FolderOpen, Settings, Plug, FileCode, Bot, Store, Zap, Terminal, Sparkles, Layers, PanelBottom, RotateCw } from 'lucide-svelte';
 	import { onMount } from 'svelte';
 	import { getVersion } from '@tauri-apps/api/app';
 
@@ -24,6 +24,7 @@
 		{ href: '/hooks', label: 'Hooks', icon: Zap },
 		{ href: '/profiles', label: 'Profiles', icon: Layers },
 		{ href: '/statusline', label: 'Status Line', icon: PanelBottom },
+		{ href: '/spinnerverbs', label: 'Spinner Verbs', icon: RotateCw },
 		{ href: '/marketplace', label: 'Marketplace', icon: Store },
 		{ href: '/settings', label: 'Global Settings', icon: Settings }
 	];

--- a/src/lib/components/spinnerverbs/SpinnerVerbForm.svelte
+++ b/src/lib/components/spinnerverbs/SpinnerVerbForm.svelte
@@ -1,0 +1,59 @@
+<script lang="ts">
+	import type { SpinnerVerb } from '$lib/types';
+
+	type Props = {
+		initialValues?: SpinnerVerb | null;
+		onSubmit: (verb: string) => void;
+		onCancel: () => void;
+	};
+
+	let { initialValues = null, onSubmit, onCancel }: Props = $props();
+
+	let verb = $state(initialValues?.verb ?? '');
+
+	const isValid = $derived(verb.trim().length > 0);
+
+	function handleSubmit(e: Event) {
+		e.preventDefault();
+		if (!isValid) return;
+		onSubmit(verb.trim());
+	}
+</script>
+
+<form onsubmit={handleSubmit} class="space-y-4">
+	<div>
+		<label
+			for="spinner-verb"
+			class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1"
+		>
+			Verb <span class="text-red-500">*</span>
+		</label>
+		<input
+			id="spinner-verb"
+			type="text"
+			bind:value={verb}
+			placeholder="e.g., Pondering, Crafting, Brewing"
+			class="w-full px-3 py-2 rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-white focus:ring-2 focus:ring-primary-500 focus:border-transparent"
+		/>
+		<p class="mt-1 text-xs text-gray-500 dark:text-gray-400">
+			The verb shown in Claude Code's spinner while it's working
+		</p>
+	</div>
+
+	<div class="flex justify-end gap-3 pt-2">
+		<button
+			type="button"
+			onclick={onCancel}
+			class="px-4 py-2 text-sm font-medium rounded-lg border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors"
+		>
+			Cancel
+		</button>
+		<button
+			type="submit"
+			disabled={!isValid}
+			class="px-4 py-2 text-sm font-medium rounded-lg bg-primary-600 text-white hover:bg-primary-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+		>
+			{initialValues ? 'Update' : 'Add'} Verb
+		</button>
+	</div>
+</form>

--- a/src/lib/components/spinnerverbs/SpinnerVerbList.svelte
+++ b/src/lib/components/spinnerverbs/SpinnerVerbList.svelte
@@ -1,0 +1,97 @@
+<script lang="ts">
+	import { GripVertical, Pencil, Trash2 } from 'lucide-svelte';
+	import { spinnerVerbLibrary } from '$lib/stores';
+	import type { SpinnerVerb } from '$lib/types';
+
+	type Props = {
+		onEdit: (verb: SpinnerVerb) => void;
+		onDelete: (verb: SpinnerVerb) => void;
+	};
+
+	let { onEdit, onDelete }: Props = $props();
+
+	let draggedIndex = $state<number | null>(null);
+	let dragOverIndex = $state<number | null>(null);
+
+	function handleDragStart(index: number) {
+		draggedIndex = index;
+	}
+
+	function handleDragOver(e: DragEvent, index: number) {
+		e.preventDefault();
+		dragOverIndex = index;
+	}
+
+	function handleDragEnd() {
+		if (draggedIndex !== null && dragOverIndex !== null && draggedIndex !== dragOverIndex) {
+			const verbs = [...spinnerVerbLibrary.verbs];
+			const [moved] = verbs.splice(draggedIndex, 1);
+			verbs.splice(dragOverIndex, 0, moved);
+			const ids = verbs.map((v) => v.id);
+			spinnerVerbLibrary.reorder(ids);
+		}
+		draggedIndex = null;
+		dragOverIndex = null;
+	}
+
+	async function handleToggle(verb: SpinnerVerb) {
+		await spinnerVerbLibrary.update(verb.id, verb.verb, !verb.isEnabled);
+	}
+</script>
+
+{#if spinnerVerbLibrary.verbs.length === 0}
+	<div class="text-center py-12">
+		<p class="text-gray-500 dark:text-gray-400">No spinner verbs yet. Add one to get started.</p>
+	</div>
+{:else}
+	<div class="space-y-2">
+		{#each spinnerVerbLibrary.verbs as verb, index (verb.id)}
+			<div
+				class="flex items-center gap-3 px-4 py-3 rounded-lg border transition-colors
+					{dragOverIndex === index ? 'border-primary-400 bg-primary-50 dark:bg-primary-900/20' : 'border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800'}
+					{!verb.isEnabled ? 'opacity-50' : ''}"
+				draggable="true"
+				ondragstart={() => handleDragStart(index)}
+				ondragover={(e) => handleDragOver(e, index)}
+				ondragend={handleDragEnd}
+				role="listitem"
+			>
+				<button
+					class="cursor-grab text-gray-400 hover:text-gray-600 dark:hover:text-gray-300"
+					aria-label="Drag to reorder"
+				>
+					<GripVertical class="w-4 h-4" />
+				</button>
+
+				<label class="flex items-center gap-3 flex-1 cursor-pointer">
+					<input
+						type="checkbox"
+						checked={verb.isEnabled}
+						onchange={() => handleToggle(verb)}
+						class="w-4 h-4 rounded border-gray-300 dark:border-gray-600 text-primary-600 focus:ring-primary-500"
+					/>
+					<span class="text-sm font-medium text-gray-900 dark:text-white">
+						{verb.verb}
+					</span>
+				</label>
+
+				<div class="flex items-center gap-1">
+					<button
+						onclick={() => onEdit(verb)}
+						class="p-1.5 rounded-lg text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors"
+						aria-label="Edit verb"
+					>
+						<Pencil class="w-4 h-4" />
+					</button>
+					<button
+						onclick={() => onDelete(verb)}
+						class="p-1.5 rounded-lg text-gray-400 hover:text-red-600 dark:hover:text-red-400 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors"
+						aria-label="Delete verb"
+					>
+						<Trash2 class="w-4 h-4" />
+					</button>
+				</div>
+			</div>
+		{/each}
+	</div>
+{/if}

--- a/src/lib/components/spinnerverbs/index.ts
+++ b/src/lib/components/spinnerverbs/index.ts
@@ -1,0 +1,2 @@
+export { default as SpinnerVerbList } from './SpinnerVerbList.svelte';
+export { default as SpinnerVerbForm } from './SpinnerVerbForm.svelte';

--- a/src/lib/stores/index.ts
+++ b/src/lib/stores/index.ts
@@ -13,4 +13,5 @@ export { claudeJson, type ClaudeJsonMcp, type ClaudeJsonProject } from './claude
 export { updater, type UpdateStatus } from './updater.svelte';
 export { whatsNew, type ReleaseInfo } from './whatsNew.svelte';
 export { profileLibrary } from './profileLibrary.svelte';
+export { spinnerVerbLibrary } from './spinnerVerbLibrary.svelte';
 export { statuslineLibrary } from './statuslineLibrary.svelte';

--- a/src/lib/stores/spinnerVerbLibrary.svelte.ts
+++ b/src/lib/stores/spinnerVerbLibrary.svelte.ts
@@ -1,0 +1,79 @@
+import { invoke } from '@tauri-apps/api/core';
+import type { SpinnerVerb } from '$lib/types';
+
+class SpinnerVerbLibraryState {
+	verbs = $state<SpinnerVerb[]>([]);
+	mode = $state<'append' | 'replace'>('append');
+	isLoading = $state(false);
+	error = $state<string | null>(null);
+
+	async load() {
+		console.log('[spinnerVerbLibrary] Loading spinner verbs...');
+		this.isLoading = true;
+		this.error = null;
+		try {
+			this.verbs = await invoke<SpinnerVerb[]>('get_all_spinner_verbs');
+			this.mode = (await invoke<string>('get_spinner_verb_mode')) as 'append' | 'replace';
+			console.log(
+				`[spinnerVerbLibrary] Loaded ${this.verbs.length} verbs, mode=${this.mode}`
+			);
+		} catch (e) {
+			this.error = String(e);
+			console.error('[spinnerVerbLibrary] Failed to load spinner verbs:', e);
+		} finally {
+			this.isLoading = false;
+		}
+	}
+
+	async create(verb: string): Promise<SpinnerVerb> {
+		console.log(`[spinnerVerbLibrary] Creating verb: ${verb}`);
+		const created = await invoke<SpinnerVerb>('create_spinner_verb', { verb });
+		this.verbs = [...this.verbs, created];
+		console.log(`[spinnerVerbLibrary] Created verb id=${created.id}`);
+		return created;
+	}
+
+	async update(id: number, verb: string, isEnabled: boolean): Promise<SpinnerVerb> {
+		console.log(`[spinnerVerbLibrary] Updating verb id=${id}: ${verb}`);
+		const updated = await invoke<SpinnerVerb>('update_spinner_verb', { id, verb, isEnabled });
+		this.verbs = this.verbs.map((v) => (v.id === id ? updated : v));
+		console.log(`[spinnerVerbLibrary] Updated verb id=${id}`);
+		return updated;
+	}
+
+	async delete(id: number): Promise<void> {
+		console.log(`[spinnerVerbLibrary] Deleting verb id=${id}`);
+		await invoke('delete_spinner_verb', { id });
+		this.verbs = this.verbs.filter((v) => v.id !== id);
+		console.log(`[spinnerVerbLibrary] Deleted verb id=${id}`);
+	}
+
+	async reorder(ids: number[]): Promise<void> {
+		console.log(`[spinnerVerbLibrary] Reordering ${ids.length} verbs`);
+		await invoke('reorder_spinner_verbs', { ids });
+		// Reorder local state to match
+		const verbMap = new Map(this.verbs.map((v) => [v.id, v]));
+		this.verbs = ids
+			.map((id, index) => {
+				const verb = verbMap.get(id);
+				if (verb) {
+					return { ...verb, displayOrder: index };
+				}
+				return null;
+			})
+			.filter((v): v is SpinnerVerb => v !== null);
+	}
+
+	async setMode(mode: 'append' | 'replace'): Promise<void> {
+		console.log(`[spinnerVerbLibrary] Setting mode to: ${mode}`);
+		await invoke('set_spinner_verb_mode', { mode });
+		this.mode = mode;
+	}
+
+	async sync(): Promise<void> {
+		console.log('[spinnerVerbLibrary] Syncing to settings.json');
+		await invoke('sync_spinner_verbs');
+	}
+}
+
+export const spinnerVerbLibrary = new SpinnerVerbLibraryState();

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -7,5 +7,6 @@ export * from './project';
 export * from './repo';
 export * from './skill';
 export * from './sound';
+export * from './spinnerVerb';
 export * from './statusline';
 export * from './subagent';

--- a/src/lib/types/spinnerVerb.ts
+++ b/src/lib/types/spinnerVerb.ts
@@ -1,0 +1,8 @@
+export interface SpinnerVerb {
+	id: number;
+	verb: string;
+	isEnabled: boolean;
+	displayOrder: number;
+	createdAt: string;
+	updatedAt: string;
+}

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -5,7 +5,7 @@
 	import { Toast } from '$lib/components/shared';
 	import UpdateNotification from '$lib/components/shared/UpdateNotification.svelte';
 	import WhatsNewModal from '$lib/components/shared/WhatsNewModal.svelte';
-	import { mcpLibrary, projectsStore, skillLibrary, subagentLibrary, hookLibrary, commandLibrary, statuslineLibrary, whatsNew, debugStore } from '$lib/stores';
+	import { mcpLibrary, projectsStore, skillLibrary, subagentLibrary, hookLibrary, commandLibrary, statuslineLibrary, spinnerVerbLibrary, whatsNew, debugStore } from '$lib/stores';
 	import { installDebugInterceptor } from '$lib/utils/debugLogger';
 
 	let { children } = $props();
@@ -24,7 +24,8 @@
 			hookLibrary.loadGlobalHooks(),
 			commandLibrary.load(),
 			commandLibrary.loadGlobalCommands(),
-			statuslineLibrary.load()
+			statuslineLibrary.load(),
+			spinnerVerbLibrary.load()
 		]);
 
 		// Load debug state and install interceptor if enabled

--- a/src/routes/spinnerverbs/+page.svelte
+++ b/src/routes/spinnerverbs/+page.svelte
@@ -1,0 +1,164 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import { Header } from '$lib/components/layout';
+	import { SpinnerVerbList, SpinnerVerbForm } from '$lib/components/spinnerverbs';
+	import { ConfirmDialog } from '$lib/components/shared';
+	import { spinnerVerbLibrary, notifications } from '$lib/stores';
+	import type { SpinnerVerb } from '$lib/types';
+	import { Plus, RefreshCw } from 'lucide-svelte';
+
+	let showAddVerb = $state(false);
+	let editingVerb = $state<SpinnerVerb | null>(null);
+	let deletingVerb = $state<SpinnerVerb | null>(null);
+	let isSyncing = $state(false);
+
+	onMount(async () => {
+		await spinnerVerbLibrary.load();
+	});
+
+	async function handleCreate(verb: string) {
+		try {
+			await spinnerVerbLibrary.create(verb);
+			showAddVerb = false;
+			notifications.success('Spinner verb added');
+		} catch (err) {
+			notifications.error('Failed to add spinner verb: ' + String(err));
+		}
+	}
+
+	async function handleUpdate(verb: string) {
+		if (!editingVerb) return;
+		try {
+			await spinnerVerbLibrary.update(editingVerb.id, verb, editingVerb.isEnabled);
+			editingVerb = null;
+			notifications.success('Spinner verb updated');
+		} catch (err) {
+			notifications.error('Failed to update spinner verb: ' + String(err));
+		}
+	}
+
+	async function handleDelete() {
+		if (!deletingVerb) return;
+		try {
+			await spinnerVerbLibrary.delete(deletingVerb.id);
+			notifications.success('Spinner verb deleted');
+		} catch (err) {
+			notifications.error('Failed to delete spinner verb');
+		} finally {
+			deletingVerb = null;
+		}
+	}
+
+	async function handleModeChange(e: Event) {
+		const target = e.target as HTMLSelectElement;
+		const mode = target.value as 'append' | 'replace';
+		try {
+			await spinnerVerbLibrary.setMode(mode);
+			notifications.success(`Mode set to "${mode}"`);
+		} catch (err) {
+			notifications.error('Failed to change mode');
+		}
+	}
+
+	async function handleSync() {
+		isSyncing = true;
+		try {
+			await spinnerVerbLibrary.sync();
+			notifications.success('Spinner verbs synced to settings.json');
+		} catch (err) {
+			notifications.error('Failed to sync: ' + String(err));
+		} finally {
+			isSyncing = false;
+		}
+	}
+</script>
+
+<Header
+	title="Spinner Verbs"
+	subtitle="Customize the action verbs shown in Claude Code's spinner while it's working"
+/>
+
+<div class="flex-1 overflow-auto p-6">
+	<!-- Mode & Actions Bar -->
+	<div class="flex items-center justify-between mb-6">
+		<div class="flex items-center gap-4">
+			<label
+				for="spinner-mode"
+				class="text-sm font-medium text-gray-700 dark:text-gray-300"
+			>
+				Mode:
+			</label>
+			<select
+				id="spinner-mode"
+				value={spinnerVerbLibrary.mode}
+				onchange={handleModeChange}
+				class="px-3 py-1.5 rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-white text-sm focus:ring-2 focus:ring-primary-500 focus:border-transparent"
+			>
+				<option value="append">Append (add to defaults)</option>
+				<option value="replace">Replace (use only these)</option>
+			</select>
+		</div>
+
+		<div class="flex items-center gap-3">
+			<button
+				onclick={handleSync}
+				disabled={isSyncing}
+				class="btn btn-secondary flex items-center gap-2"
+			>
+				<RefreshCw class="w-4 h-4 {isSyncing ? 'animate-spin' : ''}" />
+				Sync to Settings
+			</button>
+			<button onclick={() => (showAddVerb = true)} class="btn btn-primary">
+				<Plus class="w-4 h-4 mr-2" />
+				Add Verb
+			</button>
+		</div>
+	</div>
+
+	<!-- Verb List -->
+	<SpinnerVerbList
+		onEdit={(verb) => (editingVerb = verb)}
+		onDelete={(verb) => (deletingVerb = verb)}
+	/>
+</div>
+
+<!-- Add Verb Modal -->
+{#if showAddVerb}
+	<div class="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+		<div class="bg-white dark:bg-gray-800 rounded-xl shadow-xl max-w-md w-full mx-4">
+			<div class="p-6">
+				<h2 class="text-xl font-semibold text-gray-900 dark:text-white mb-6">
+					Add Spinner Verb
+				</h2>
+				<SpinnerVerbForm onSubmit={handleCreate} onCancel={() => (showAddVerb = false)} />
+			</div>
+		</div>
+	</div>
+{/if}
+
+<!-- Edit Verb Modal -->
+{#if editingVerb}
+	<div class="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+		<div class="bg-white dark:bg-gray-800 rounded-xl shadow-xl max-w-md w-full mx-4">
+			<div class="p-6">
+				<h2 class="text-xl font-semibold text-gray-900 dark:text-white mb-6">
+					Edit Spinner Verb
+				</h2>
+				<SpinnerVerbForm
+					initialValues={editingVerb}
+					onSubmit={handleUpdate}
+					onCancel={() => (editingVerb = null)}
+				/>
+			</div>
+		</div>
+	</div>
+{/if}
+
+<ConfirmDialog
+	open={!!deletingVerb}
+	title="Delete Spinner Verb"
+	message="Are you sure you want to delete '{deletingVerb?.verb}'? This cannot be undone."
+	confirmText="Delete"
+	onConfirm={handleDelete}
+	onCancel={() => (deletingVerb = null)}
+/>


### PR DESCRIPTION
## Summary
- Adds a full-stack GUI for managing Claude Code spinner verbs (the action verbs shown in the spinner while Claude works, e.g., "Pondering", "Crafting")
- Users can add/edit/delete/reorder verbs, toggle them on/off, choose append vs replace mode, and sync to `~/.claude/settings.json`
- Follows established app patterns (profiles, status line) for DB migrations, Tauri commands, Svelte stores, and components

## Changes

**Backend (Rust):**
- DB migration 14: `spinner_verbs` and `spinner_verb_config` tables
- `SpinnerVerb` / `SpinnerVerbConfig` model structs in `models.rs`
- `spinner_verb_writer` service for reading/writing `spinnerVerbs` key in `settings.json`
- 9 Tauri commands: CRUD, reorder, mode get/set, sync to settings, read current config
- 9 unit tests (all passing, 770 total)

**Frontend (Svelte/TypeScript):**
- `SpinnerVerb` TypeScript interface
- `spinnerVerbLibrary` Svelte 5 reactive store
- `SpinnerVerbList` component with drag-to-reorder, enable/disable toggles, edit/delete
- `SpinnerVerbForm` modal component for add/edit
- `/spinnerverbs` route page with mode toggle (append/replace) and "Sync to Settings" button
- Sidebar nav entry with `RotateCw` icon

## Test plan
- [x] `cargo build` compiles successfully
- [x] `cargo test` — all 770 tests pass (9 new spinner verb tests)
- [ ] Launch app and verify "Spinner Verbs" appears in sidebar
- [ ] Add/edit/delete verbs through the UI
- [ ] Toggle verbs on/off, drag to reorder
- [ ] Switch between append and replace modes
- [ ] Click "Sync to Settings" and verify `~/.claude/settings.json` contains correct `spinnerVerbs` config
- [ ] Verify other settings.json keys (statusLine, etc.) are preserved after sync

Closes #107

🤖 Generated with [Claude Code](https://claude.com/claude-code)