### PR TITLE
Add Insights Viewer with session quality and friction analysis

### DIFF
--- a/src-tauri/src/commands/insights.rs
+++ b/src-tauri/src/commands/insights.rs
@@ -1,0 +1,16 @@
+use crate::services::insights::{self, InsightsReportInfo, SessionFacetsInfo};
+use log::info;
+
+/// Get the insights report HTML from ~/.claude/usage-data/report.html
+#[tauri::command]
+pub fn get_insights_report() -> Result<InsightsReportInfo, String> {
+    info!("[Insights] Reading insights report");
+    insights::read_insights_report().map_err(|e| e.to_string())
+}
+
+/// Get all session facets from ~/.claude/usage-data/facets/
+#[tauri::command]
+pub fn get_session_facets() -> Result<SessionFacetsInfo, String> {
+    info!("[Insights] Reading session facets");
+    insights::read_all_facets().map_err(|e| e.to_string())
+}

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -5,6 +5,7 @@ pub mod commands;
 pub mod config;
 pub mod debug;
 pub mod hooks;
+pub mod insights;
 pub mod keybindings;
 pub mod managed_settings;
 pub mod mcp;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -452,6 +452,9 @@ pub fn run() {
             commands::managed_settings::get_managed_settings,
             // Analytics Commands
             commands::analytics::get_usage_stats,
+            // Insights Commands
+            commands::insights::get_insights_report,
+            commands::insights::get_session_facets,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src-tauri/src/services/insights.rs
+++ b/src-tauri/src/services/insights.rs
@@ -1,0 +1,271 @@
+use anyhow::Result;
+use log::warn;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+
+/// Top-level response for the insights report HTML
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct InsightsReportInfo {
+    pub file_path: String,
+    pub exists: bool,
+    pub html_content: Option<String>,
+}
+
+/// Top-level response for all session facets
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionFacetsInfo {
+    pub dir_path: String,
+    pub exists: bool,
+    pub facets: Vec<SessionFacet>,
+}
+
+/// A single session's quality facets.
+/// JSON files use snake_case keys; we serialize as camelCase for the frontend.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionFacet {
+    #[serde(alias = "session_id")]
+    pub session_id: String,
+
+    #[serde(alias = "underlying_goal", default)]
+    pub underlying_goal: String,
+
+    #[serde(alias = "goal_categories", default)]
+    pub goal_categories: HashMap<String, u64>,
+
+    #[serde(default)]
+    pub outcome: String,
+
+    #[serde(alias = "user_satisfaction_counts", default)]
+    pub user_satisfaction_counts: HashMap<String, u64>,
+
+    #[serde(alias = "claude_helpfulness", default)]
+    pub claude_helpfulness: String,
+
+    #[serde(alias = "session_type", default)]
+    pub session_type: String,
+
+    #[serde(alias = "friction_counts", default)]
+    pub friction_counts: HashMap<String, u64>,
+
+    #[serde(alias = "friction_detail", default)]
+    pub friction_detail: String,
+
+    #[serde(alias = "primary_success", default)]
+    pub primary_success: String,
+
+    #[serde(alias = "brief_summary", default)]
+    pub brief_summary: String,
+}
+
+/// Get the path to ~/.claude/usage-data/
+fn usage_data_dir() -> PathBuf {
+    if let Some(base) = directories::BaseDirs::new() {
+        base.home_dir().join(".claude").join("usage-data")
+    } else {
+        PathBuf::from("~/.claude/usage-data")
+    }
+}
+
+/// Read the insights report HTML from the default location
+pub fn read_insights_report() -> Result<InsightsReportInfo> {
+    let dir = usage_data_dir();
+    let path = dir.join("report.html");
+    read_insights_report_from_path(&path)
+}
+
+/// Read the insights report HTML from a given path (testable variant)
+pub fn read_insights_report_from_path(path: &Path) -> Result<InsightsReportInfo> {
+    let file_path = path.to_string_lossy().to_string();
+
+    if !path.exists() {
+        return Ok(InsightsReportInfo {
+            file_path,
+            exists: false,
+            html_content: None,
+        });
+    }
+
+    let content = std::fs::read_to_string(path)?;
+    Ok(InsightsReportInfo {
+        file_path,
+        exists: true,
+        html_content: Some(content),
+    })
+}
+
+/// Read all session facets from the default location
+pub fn read_all_facets() -> Result<SessionFacetsInfo> {
+    let dir = usage_data_dir();
+    let facets_dir = dir.join("facets");
+    read_all_facets_from_dir(&facets_dir)
+}
+
+/// Read all session facets from a given directory (testable variant)
+pub fn read_all_facets_from_dir(dir: &Path) -> Result<SessionFacetsInfo> {
+    let dir_path = dir.to_string_lossy().to_string();
+
+    if !dir.exists() {
+        return Ok(SessionFacetsInfo {
+            dir_path,
+            exists: false,
+            facets: Vec::new(),
+        });
+    }
+
+    let mut facets = Vec::new();
+
+    let entries = std::fs::read_dir(dir)?;
+    for entry in entries {
+        let entry = entry?;
+        let path = entry.path();
+
+        if path.extension().and_then(|e| e.to_str()) != Some("json") {
+            continue;
+        }
+
+        match std::fs::read_to_string(&path) {
+            Ok(content) => match serde_json::from_str::<SessionFacet>(&content) {
+                Ok(facet) => facets.push(facet),
+                Err(e) => {
+                    warn!(
+                        "[Insights] Skipping unparseable facet file {}: {}",
+                        path.display(),
+                        e
+                    );
+                }
+            },
+            Err(e) => {
+                warn!(
+                    "[Insights] Skipping unreadable facet file {}: {}",
+                    path.display(),
+                    e
+                );
+            }
+        }
+    }
+
+    facets.sort_by(|a, b| a.session_id.cmp(&b.session_id));
+
+    Ok(SessionFacetsInfo {
+        dir_path,
+        exists: true,
+        facets,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_nonexistent_report_returns_not_found() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("report.html");
+
+        let info = read_insights_report_from_path(&path).unwrap();
+        assert!(!info.exists);
+        assert!(info.html_content.is_none());
+    }
+
+    #[test]
+    fn test_valid_report_reads() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("report.html");
+        std::fs::write(&path, "<html><body>Test</body></html>").unwrap();
+
+        let info = read_insights_report_from_path(&path).unwrap();
+        assert!(info.exists);
+        assert_eq!(info.html_content.unwrap(), "<html><body>Test</body></html>");
+    }
+
+    #[test]
+    fn test_nonexistent_facets_dir_returns_not_found() {
+        let dir = tempfile::tempdir().unwrap();
+        let facets_dir = dir.path().join("facets");
+
+        let info = read_all_facets_from_dir(&facets_dir).unwrap();
+        assert!(!info.exists);
+        assert!(info.facets.is_empty());
+    }
+
+    #[test]
+    fn test_valid_facet_parses() {
+        let dir = tempfile::tempdir().unwrap();
+        let facets_dir = dir.path().join("facets");
+        std::fs::create_dir(&facets_dir).unwrap();
+
+        std::fs::write(
+            facets_dir.join("abc-123.json"),
+            r#"{
+                "session_id": "abc-123",
+                "underlying_goal": "Fix a bug",
+                "goal_categories": { "bug_fix": 1 },
+                "outcome": "fully_achieved",
+                "user_satisfaction_counts": { "satisfied": 3 },
+                "claude_helpfulness": "essential",
+                "session_type": "single_task",
+                "friction_counts": { "tool_failures": 1 },
+                "friction_detail": "One tool call failed",
+                "primary_success": "true",
+                "brief_summary": "Fixed the login bug"
+            }"#,
+        )
+        .unwrap();
+
+        let info = read_all_facets_from_dir(&facets_dir).unwrap();
+        assert!(info.exists);
+        assert_eq!(info.facets.len(), 1);
+
+        let f = &info.facets[0];
+        assert_eq!(f.session_id, "abc-123");
+        assert_eq!(f.underlying_goal, "Fix a bug");
+        assert_eq!(f.outcome, "fully_achieved");
+        assert_eq!(f.claude_helpfulness, "essential");
+        assert_eq!(f.brief_summary, "Fixed the login bug");
+        assert_eq!(f.goal_categories.get("bug_fix"), Some(&1));
+        assert_eq!(f.friction_counts.get("tool_failures"), Some(&1));
+    }
+
+    #[test]
+    fn test_unparseable_facets_are_skipped() {
+        let dir = tempfile::tempdir().unwrap();
+        let facets_dir = dir.path().join("facets");
+        std::fs::create_dir(&facets_dir).unwrap();
+
+        // Valid facet
+        std::fs::write(
+            facets_dir.join("good.json"),
+            r#"{ "session_id": "good-1", "outcome": "fully_achieved" }"#,
+        )
+        .unwrap();
+
+        // Invalid JSON
+        std::fs::write(facets_dir.join("bad.json"), "not json").unwrap();
+
+        // Non-JSON file (should be skipped)
+        std::fs::write(facets_dir.join("readme.txt"), "ignore me").unwrap();
+
+        let info = read_all_facets_from_dir(&facets_dir).unwrap();
+        assert!(info.exists);
+        assert_eq!(info.facets.len(), 1);
+        assert_eq!(info.facets[0].session_id, "good-1");
+    }
+
+    #[test]
+    fn test_facets_sorted_by_session_id() {
+        let dir = tempfile::tempdir().unwrap();
+        let facets_dir = dir.path().join("facets");
+        std::fs::create_dir(&facets_dir).unwrap();
+
+        std::fs::write(facets_dir.join("z.json"), r#"{ "session_id": "zzz" }"#).unwrap();
+        std::fs::write(facets_dir.join("a.json"), r#"{ "session_id": "aaa" }"#).unwrap();
+
+        let info = read_all_facets_from_dir(&facets_dir).unwrap();
+        assert_eq!(info.facets[0].session_id, "aaa");
+        assert_eq!(info.facets[1].session_id, "zzz");
+    }
+}

--- a/src-tauri/src/services/mod.rs
+++ b/src-tauri/src/services/mod.rs
@@ -10,6 +10,7 @@ pub mod debug_logger;
 pub mod gemini_config;
 pub mod github_client;
 pub mod hook_writer;
+pub mod insights;
 pub mod keybindings_writer;
 pub mod managed_settings;
 pub mod mcp_client;

--- a/src/lib/components/analytics/FrictionTrendsChart.svelte
+++ b/src/lib/components/analytics/FrictionTrendsChart.svelte
@@ -1,0 +1,66 @@
+<script lang="ts">
+	import type { SessionFacet } from '$lib/types';
+	import { FRICTION_LABELS } from '$lib/types/insights';
+
+	type Props = {
+		facets: SessionFacet[];
+	};
+
+	let { facets }: Props = $props();
+
+	const frictionCounts = $derived.by(() => {
+		const counts: Record<string, number> = {};
+		for (const f of facets) {
+			for (const [key, value] of Object.entries(f.frictionCounts)) {
+				counts[key] = (counts[key] || 0) + value;
+			}
+		}
+		return Object.entries(counts).sort((a, b) => b[1] - a[1]);
+	});
+
+	const maxCount = $derived(
+		frictionCounts.length > 0 ? Math.max(...frictionCounts.map(([, c]) => c)) : 0
+	);
+
+	const barColors = [
+		'#ef4444', '#f59e0b', '#3b82f6', '#8b5cf6',
+		'#10b981', '#ec4899', '#06b6d4', '#f97316'
+	];
+</script>
+
+<div
+	class="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 p-4"
+>
+	<h3 class="text-sm font-semibold text-gray-900 dark:text-white mb-4">
+		Friction Categories
+	</h3>
+
+	{#if frictionCounts.length === 0}
+		<div class="flex items-center justify-center py-12 text-gray-400 dark:text-gray-500">
+			No friction data recorded
+		</div>
+	{:else}
+		<div class="space-y-3">
+			{#each frictionCounts as [key, count], i}
+				{@const pct = maxCount > 0 ? (count / maxCount) * 100 : 0}
+				{@const color = barColors[i % barColors.length]}
+				<div>
+					<div class="flex items-center justify-between mb-1">
+						<span class="text-xs font-medium text-gray-600 dark:text-gray-300">
+							{FRICTION_LABELS[key] || key}
+						</span>
+						<span class="text-xs text-gray-400 dark:text-gray-500">
+							{count}
+						</span>
+					</div>
+					<div class="w-full h-5 bg-gray-100 dark:bg-gray-700 rounded-full overflow-hidden">
+						<div
+							class="h-full rounded-full transition-all duration-500"
+							style="width: {pct}%; background: {color};"
+						></div>
+					</div>
+				</div>
+			{/each}
+		</div>
+	{/if}
+</div>

--- a/src/lib/components/analytics/InsightsReportViewer.svelte
+++ b/src/lib/components/analytics/InsightsReportViewer.svelte
@@ -1,0 +1,59 @@
+<script lang="ts">
+	import { invoke } from '@tauri-apps/api/core';
+	import { ExternalLink, RefreshCw } from 'lucide-svelte';
+	import { notifications } from '$lib/stores';
+
+	type Props = {
+		htmlContent: string;
+		filePath: string;
+		onRefresh?: () => void;
+	};
+
+	let { htmlContent, filePath, onRefresh }: Props = $props();
+
+	async function openInBrowser() {
+		try {
+			await invoke('open_config_file', { path: filePath });
+		} catch (err) {
+			notifications.error('Failed to open report in browser');
+			console.error('Failed to open report:', err);
+		}
+	}
+</script>
+
+<div
+	class="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 p-4"
+>
+	<div class="flex items-center justify-between mb-4">
+		<h3 class="text-sm font-semibold text-gray-900 dark:text-white">Insights Report</h3>
+		<div class="flex items-center gap-2">
+			{#if onRefresh}
+				<button
+					onclick={onRefresh}
+					class="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium text-gray-600 dark:text-gray-300 bg-gray-100 dark:bg-gray-700 hover:bg-gray-200 dark:hover:bg-gray-600 rounded-lg transition-colors"
+					title="Refresh insights"
+				>
+					<RefreshCw class="w-3.5 h-3.5" />
+					Refresh
+				</button>
+			{/if}
+			<button
+				onclick={openInBrowser}
+				class="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium text-gray-600 dark:text-gray-300 bg-gray-100 dark:bg-gray-700 hover:bg-gray-200 dark:hover:bg-gray-600 rounded-lg transition-colors"
+			>
+				<ExternalLink class="w-3.5 h-3.5" />
+				Open in Browser
+			</button>
+		</div>
+	</div>
+
+	<div class="rounded-lg overflow-hidden border border-gray-200 dark:border-gray-700">
+		<iframe
+			srcdoc={htmlContent}
+			title="Claude Code Insights Report"
+			class="w-full bg-white"
+			style="height: 600px; border: none;"
+			sandbox="allow-scripts allow-same-origin"
+		></iframe>
+	</div>
+</div>

--- a/src/lib/components/analytics/SessionQualityCards.svelte
+++ b/src/lib/components/analytics/SessionQualityCards.svelte
@@ -1,0 +1,210 @@
+<script lang="ts">
+	import type { SessionFacet } from '$lib/types';
+	import {
+		OUTCOME_LABELS,
+		OUTCOME_COLORS,
+		HELPFULNESS_LABELS,
+		HELPFULNESS_COLORS
+	} from '$lib/types/insights';
+
+	type Props = {
+		facets: SessionFacet[];
+	};
+
+	let { facets }: Props = $props();
+
+	const outcomeCounts = $derived.by(() => {
+		const counts: Record<string, number> = {};
+		for (const f of facets) {
+			if (f.outcome) counts[f.outcome] = (counts[f.outcome] || 0) + 1;
+		}
+		return Object.entries(counts).sort((a, b) => b[1] - a[1]);
+	});
+
+	const helpfulnessCounts = $derived.by(() => {
+		const counts: Record<string, number> = {};
+		for (const f of facets) {
+			if (f.claudeHelpfulness) counts[f.claudeHelpfulness] = (counts[f.claudeHelpfulness] || 0) + 1;
+		}
+		return Object.entries(counts).sort((a, b) => b[1] - a[1]);
+	});
+
+	const outcomeTotal = $derived(outcomeCounts.reduce((s, [, c]) => s + c, 0));
+	const helpfulnessTotal = $derived(helpfulnessCounts.reduce((s, [, c]) => s + c, 0));
+
+	// Donut chart helpers
+	const cx = 80;
+	const cy = 80;
+	const radius = 55;
+	const strokeWidth = 18;
+	const circumference = 2 * Math.PI * radius;
+
+	function makeSegments(
+		entries: [string, number][],
+		total: number,
+		colors: Record<string, string>
+	) {
+		let offset = 0;
+		return entries.map(([key, count]) => {
+			const pct = total > 0 ? count / total : 0;
+			const dash = circumference * pct;
+			const seg = {
+				key,
+				count,
+				pct,
+				color: colors[key] || '#9ca3af',
+				dashArray: `${dash} ${circumference - dash}`,
+				dashOffset: -offset
+			};
+			offset += dash;
+			return seg;
+		});
+	}
+
+	const outcomeSegments = $derived(makeSegments(outcomeCounts, outcomeTotal, OUTCOME_COLORS));
+	const helpfulnessSegments = $derived(
+		makeSegments(helpfulnessCounts, helpfulnessTotal, HELPFULNESS_COLORS)
+	);
+</script>
+
+<div class="grid grid-cols-1 lg:grid-cols-2 gap-6">
+	<!-- Outcome Distribution -->
+	<div
+		class="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 p-4"
+	>
+		<h3 class="text-sm font-semibold text-gray-900 dark:text-white mb-4">
+			Session Outcomes
+		</h3>
+
+		{#if outcomeCounts.length === 0}
+			<div class="flex items-center justify-center py-12 text-gray-400 dark:text-gray-500">
+				No outcome data available
+			</div>
+		{:else}
+			<div class="flex flex-col items-center gap-4">
+				<svg viewBox="0 0 160 160" class="w-40 h-40">
+					{#each outcomeSegments as seg}
+						<circle
+							{cx}
+							{cy}
+							r={radius}
+							fill="none"
+							stroke={seg.color}
+							stroke-width={strokeWidth}
+							stroke-dasharray={seg.dashArray}
+							stroke-dashoffset={seg.dashOffset}
+							transform="rotate(-90 {cx} {cy})"
+							class="transition-all duration-300"
+						/>
+					{/each}
+					<text
+						x={cx}
+						y={cy - 4}
+						text-anchor="middle"
+						class="fill-gray-900 dark:fill-white"
+						font-size="18"
+						font-weight="bold"
+					>
+						{outcomeTotal}
+					</text>
+					<text
+						x={cx}
+						y={cy + 12}
+						text-anchor="middle"
+						class="fill-gray-400 dark:fill-gray-500"
+						font-size="10"
+					>
+						sessions
+					</text>
+				</svg>
+
+				<div class="flex flex-wrap justify-center gap-3">
+					{#each outcomeSegments as seg}
+						<div class="flex items-center gap-1.5">
+							<div
+								class="w-2.5 h-2.5 rounded-full"
+								style="background: {seg.color}"
+							></div>
+							<span class="text-xs text-gray-600 dark:text-gray-300">
+								{OUTCOME_LABELS[seg.key] || seg.key}
+							</span>
+							<span class="text-xs text-gray-400 dark:text-gray-500">
+								{seg.count}
+							</span>
+						</div>
+					{/each}
+				</div>
+			</div>
+		{/if}
+	</div>
+
+	<!-- Helpfulness Distribution -->
+	<div
+		class="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 p-4"
+	>
+		<h3 class="text-sm font-semibold text-gray-900 dark:text-white mb-4">
+			Claude Helpfulness
+		</h3>
+
+		{#if helpfulnessCounts.length === 0}
+			<div class="flex items-center justify-center py-12 text-gray-400 dark:text-gray-500">
+				No helpfulness data available
+			</div>
+		{:else}
+			<div class="flex flex-col items-center gap-4">
+				<svg viewBox="0 0 160 160" class="w-40 h-40">
+					{#each helpfulnessSegments as seg}
+						<circle
+							{cx}
+							{cy}
+							r={radius}
+							fill="none"
+							stroke={seg.color}
+							stroke-width={strokeWidth}
+							stroke-dasharray={seg.dashArray}
+							stroke-dashoffset={seg.dashOffset}
+							transform="rotate(-90 {cx} {cy})"
+							class="transition-all duration-300"
+						/>
+					{/each}
+					<text
+						x={cx}
+						y={cy - 4}
+						text-anchor="middle"
+						class="fill-gray-900 dark:fill-white"
+						font-size="18"
+						font-weight="bold"
+					>
+						{helpfulnessTotal}
+					</text>
+					<text
+						x={cx}
+						y={cy + 12}
+						text-anchor="middle"
+						class="fill-gray-400 dark:fill-gray-500"
+						font-size="10"
+					>
+						sessions
+					</text>
+				</svg>
+
+				<div class="flex flex-wrap justify-center gap-3">
+					{#each helpfulnessSegments as seg}
+						<div class="flex items-center gap-1.5">
+							<div
+								class="w-2.5 h-2.5 rounded-full"
+								style="background: {seg.color}"
+							></div>
+							<span class="text-xs text-gray-600 dark:text-gray-300">
+								{HELPFULNESS_LABELS[seg.key] || seg.key}
+							</span>
+							<span class="text-xs text-gray-400 dark:text-gray-500">
+								{seg.count}
+							</span>
+						</div>
+					{/each}
+				</div>
+			</div>
+		{/if}
+	</div>
+</div>

--- a/src/lib/components/analytics/SessionSummaryList.svelte
+++ b/src/lib/components/analytics/SessionSummaryList.svelte
@@ -1,0 +1,178 @@
+<script lang="ts">
+	import { ChevronDown, ChevronRight } from 'lucide-svelte';
+	import type { SessionFacet } from '$lib/types';
+	import {
+		OUTCOME_LABELS,
+		OUTCOME_COLORS,
+		HELPFULNESS_LABELS,
+		SESSION_TYPE_LABELS
+	} from '$lib/types/insights';
+
+	type Props = {
+		facets: SessionFacet[];
+	};
+
+	let { facets }: Props = $props();
+
+	let expandedIds = $state<Set<string>>(new Set());
+
+	function toggle(id: string) {
+		const next = new Set(expandedIds);
+		if (next.has(id)) {
+			next.delete(id);
+		} else {
+			next.add(id);
+		}
+		expandedIds = next;
+	}
+
+	function outcomeColor(outcome: string): string {
+		return OUTCOME_COLORS[outcome] || '#9ca3af';
+	}
+
+	function truncateId(id: string): string {
+		if (id.length <= 12) return id;
+		return id.slice(0, 8) + '...';
+	}
+</script>
+
+<div
+	class="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 p-4"
+>
+	<h3 class="text-sm font-semibold text-gray-900 dark:text-white mb-4">
+		Session Summaries
+		<span class="text-xs font-normal text-gray-400 dark:text-gray-500 ml-2">
+			{facets.length} sessions
+		</span>
+	</h3>
+
+	{#if facets.length === 0}
+		<div class="flex items-center justify-center py-12 text-gray-400 dark:text-gray-500">
+			No session data available
+		</div>
+	{:else}
+		<div class="space-y-1.5 max-h-[500px] overflow-y-auto">
+			{#each facets as facet (facet.sessionId)}
+				{@const isExpanded = expandedIds.has(facet.sessionId)}
+				<div
+					class="border border-gray-100 dark:border-gray-700/50 rounded-lg overflow-hidden"
+				>
+					<button
+						onclick={() => toggle(facet.sessionId)}
+						class="w-full flex items-center gap-3 px-3 py-2.5 text-left hover:bg-gray-50 dark:hover:bg-gray-700/30 transition-colors"
+					>
+						{#if isExpanded}
+							<ChevronDown class="w-4 h-4 text-gray-400 shrink-0" />
+						{:else}
+							<ChevronRight class="w-4 h-4 text-gray-400 shrink-0" />
+						{/if}
+
+						<div
+							class="w-2 h-2 rounded-full shrink-0"
+							style="background: {outcomeColor(facet.outcome)}"
+						></div>
+
+						<span class="text-sm text-gray-700 dark:text-gray-300 truncate flex-1">
+							{facet.briefSummary || facet.underlyingGoal || 'Untitled session'}
+						</span>
+
+						<span
+							class="text-[10px] font-mono text-gray-400 dark:text-gray-500 shrink-0"
+						>
+							{truncateId(facet.sessionId)}
+						</span>
+					</button>
+
+					{#if isExpanded}
+						<div
+							class="px-3 pb-3 pt-1 border-t border-gray-100 dark:border-gray-700/50 space-y-2"
+						>
+							{#if facet.underlyingGoal}
+								<div>
+									<span class="text-[10px] uppercase tracking-wider font-semibold text-gray-400 dark:text-gray-500">
+										Goal
+									</span>
+									<p class="text-sm text-gray-700 dark:text-gray-300 mt-0.5">
+										{facet.underlyingGoal}
+									</p>
+								</div>
+							{/if}
+
+							{#if facet.briefSummary}
+								<div>
+									<span class="text-[10px] uppercase tracking-wider font-semibold text-gray-400 dark:text-gray-500">
+										Summary
+									</span>
+									<p class="text-sm text-gray-700 dark:text-gray-300 mt-0.5">
+										{facet.briefSummary}
+									</p>
+								</div>
+							{/if}
+
+							<div class="flex flex-wrap gap-2 mt-2">
+								<span
+									class="inline-flex items-center px-2 py-0.5 rounded-full text-[10px] font-medium"
+									style="background: {outcomeColor(facet.outcome)}20; color: {outcomeColor(facet.outcome)}"
+								>
+									{OUTCOME_LABELS[facet.outcome] || facet.outcome}
+								</span>
+
+								{#if facet.claudeHelpfulness}
+									<span
+										class="inline-flex items-center px-2 py-0.5 rounded-full text-[10px] font-medium bg-purple-50 dark:bg-purple-900/20 text-purple-600 dark:text-purple-400"
+									>
+										{HELPFULNESS_LABELS[facet.claudeHelpfulness] || facet.claudeHelpfulness}
+									</span>
+								{/if}
+
+								{#if facet.sessionType}
+									<span
+										class="inline-flex items-center px-2 py-0.5 rounded-full text-[10px] font-medium bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-300"
+									>
+										{SESSION_TYPE_LABELS[facet.sessionType] || facet.sessionType}
+									</span>
+								{/if}
+
+								{#if facet.primarySuccess}
+									<span
+										class="inline-flex items-center px-2 py-0.5 rounded-full text-[10px] font-medium {facet.primarySuccess === 'true' ? 'bg-green-50 dark:bg-green-900/20 text-green-600 dark:text-green-400' : 'bg-red-50 dark:bg-red-900/20 text-red-600 dark:text-red-400'}"
+									>
+										{facet.primarySuccess === 'true' ? 'Success' : 'Not Successful'}
+									</span>
+								{/if}
+							</div>
+
+							{#if facet.frictionDetail}
+								<div>
+									<span class="text-[10px] uppercase tracking-wider font-semibold text-gray-400 dark:text-gray-500">
+										Friction
+									</span>
+									<p class="text-xs text-gray-600 dark:text-gray-400 mt-0.5">
+										{facet.frictionDetail}
+									</p>
+								</div>
+							{/if}
+
+							{#if Object.keys(facet.goalCategories).length > 0}
+								<div>
+									<span class="text-[10px] uppercase tracking-wider font-semibold text-gray-400 dark:text-gray-500">
+										Categories
+									</span>
+									<div class="flex flex-wrap gap-1 mt-0.5">
+										{#each Object.entries(facet.goalCategories) as [cat, count]}
+											<span
+												class="inline-flex items-center px-1.5 py-0.5 rounded text-[10px] bg-blue-50 dark:bg-blue-900/20 text-blue-600 dark:text-blue-400"
+											>
+												{cat}: {count}
+											</span>
+										{/each}
+									</div>
+								</div>
+							{/if}
+						</div>
+					{/if}
+				</div>
+			{/each}
+		</div>
+	{/if}
+</div>

--- a/src/lib/components/layout/Sidebar.svelte
+++ b/src/lib/components/layout/Sidebar.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { page } from '$app/stores';
-	import { Library, FolderOpen, Settings, Bot, Store, Zap, Terminal, Sparkles, Layers, PanelBottom, Shield, FileText, Plug, BarChart3 } from 'lucide-svelte';
+	import { Library, FolderOpen, Settings, Bot, Store, Zap, Terminal, Sparkles, Layers, PanelBottom, Shield, FileText, Plug, BarChart3, TrendingUp } from 'lucide-svelte';
 	import { onMount } from 'svelte';
 	import { getVersion } from '@tauri-apps/api/app';
 
@@ -58,7 +58,8 @@
 		{
 			label: 'Insights',
 			items: [
-				{ href: '/analytics', label: 'Analytics', icon: BarChart3 }
+				{ href: '/analytics', label: 'Analytics', icon: BarChart3 },
+				{ href: '/insights', label: 'Insights', icon: TrendingUp }
 			]
 		}
 	];

--- a/src/lib/stores/index.ts
+++ b/src/lib/stores/index.ts
@@ -20,3 +20,4 @@ export { memoryLibrary } from './memoryLibrary.svelte';
 export { claudeSettingsLibrary } from './claudeSettingsLibrary.svelte';
 export { keybindingsLibrary } from './keybindingsLibrary.svelte';
 export { usageStore } from './usageStore.svelte';
+export { insightsStore } from './insightsStore.svelte';

--- a/src/lib/stores/insightsStore.svelte.ts
+++ b/src/lib/stores/insightsStore.svelte.ts
@@ -1,0 +1,84 @@
+import { invoke } from '@tauri-apps/api/core';
+import type { InsightsReportInfo, SessionFacetsInfo, SessionFacet } from '$lib/types';
+
+class InsightsStoreState {
+	reportInfo = $state<InsightsReportInfo | null>(null);
+	facetsInfo = $state<SessionFacetsInfo | null>(null);
+	isLoadingReport = $state(false);
+	isLoadingFacets = $state(false);
+	reportError = $state<string | null>(null);
+	facetsError = $state<string | null>(null);
+
+	reportExists = $derived(this.reportInfo?.exists ?? false);
+	reportHtml = $derived(this.reportInfo?.htmlContent ?? null);
+	reportFilePath = $derived(this.reportInfo?.filePath ?? '');
+	facetsExist = $derived(this.facetsInfo?.exists ?? false);
+	facets = $derived(this.facetsInfo?.facets ?? []);
+
+	isLoading = $derived(this.isLoadingReport || this.isLoadingFacets);
+
+	outcomeCounts = $derived.by(() => {
+		const counts: Record<string, number> = {};
+		for (const facet of this.facets) {
+			if (facet.outcome) {
+				counts[facet.outcome] = (counts[facet.outcome] || 0) + 1;
+			}
+		}
+		return counts;
+	});
+
+	helpfulnessCounts = $derived.by(() => {
+		const counts: Record<string, number> = {};
+		for (const facet of this.facets) {
+			if (facet.claudeHelpfulness) {
+				counts[facet.claudeHelpfulness] = (counts[facet.claudeHelpfulness] || 0) + 1;
+			}
+		}
+		return counts;
+	});
+
+	aggregatedFrictionCounts = $derived.by(() => {
+		const counts: Record<string, number> = {};
+		for (const facet of this.facets) {
+			for (const [key, value] of Object.entries(facet.frictionCounts)) {
+				counts[key] = (counts[key] || 0) + value;
+			}
+		}
+		return counts;
+	});
+
+	async load() {
+		console.log('[insightsStore] Loading insights data...');
+		await Promise.all([this.loadReport(), this.loadFacets()]);
+	}
+
+	async loadReport() {
+		this.isLoadingReport = true;
+		this.reportError = null;
+		try {
+			this.reportInfo = await invoke<InsightsReportInfo>('get_insights_report');
+			console.log('[insightsStore] Loaded insights report');
+		} catch (e) {
+			this.reportError = String(e);
+			console.error('[insightsStore] Failed to load insights report:', e);
+		} finally {
+			this.isLoadingReport = false;
+		}
+	}
+
+	async loadFacets() {
+		this.isLoadingFacets = true;
+		this.facetsError = null;
+		try {
+			this.facetsInfo = await invoke<SessionFacetsInfo>('get_session_facets');
+			console.log('[insightsStore] Loaded session facets');
+		} catch (e) {
+			this.facetsError = String(e);
+			console.error('[insightsStore] Failed to load session facets:', e);
+		} finally {
+			this.isLoadingFacets = false;
+		}
+	}
+}
+
+export const insightsStore = new InsightsStoreState();

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -15,3 +15,4 @@ export * from './memory';
 export * from './claudeSettings';
 export * from './keybindings';
 export * from './usage';
+export * from './insights';

--- a/src/lib/types/insights.ts
+++ b/src/lib/types/insights.ts
@@ -1,0 +1,109 @@
+export interface InsightsReportInfo {
+	filePath: string;
+	exists: boolean;
+	htmlContent: string | null;
+}
+
+export interface SessionFacetsInfo {
+	dirPath: string;
+	exists: boolean;
+	facets: SessionFacet[];
+}
+
+export interface SessionFacet {
+	sessionId: string;
+	underlyingGoal: string;
+	goalCategories: Record<string, number>;
+	outcome: string;
+	userSatisfactionCounts: Record<string, number>;
+	claudeHelpfulness: string;
+	sessionType: string;
+	frictionCounts: Record<string, number>;
+	frictionDetail: string;
+	primarySuccess: string;
+	briefSummary: string;
+}
+
+export type SessionOutcome =
+	| 'fully_achieved'
+	| 'mostly_achieved'
+	| 'partially_achieved'
+	| 'not_achieved'
+	| 'abandoned'
+	| 'unknown';
+
+export type SatisfactionLevel =
+	| 'satisfied'
+	| 'likely_satisfied'
+	| 'neutral'
+	| 'likely_unsatisfied'
+	| 'unsatisfied';
+
+export type HelpfulnessLevel =
+	| 'essential'
+	| 'very_helpful'
+	| 'helpful'
+	| 'slightly_helpful'
+	| 'not_helpful';
+
+export type SessionType =
+	| 'single_task'
+	| 'multi_task'
+	| 'exploration'
+	| 'debugging'
+	| 'learning'
+	| 'unknown';
+
+export const OUTCOME_LABELS: Record<string, string> = {
+	fully_achieved: 'Fully Achieved',
+	mostly_achieved: 'Mostly Achieved',
+	partially_achieved: 'Partially Achieved',
+	not_achieved: 'Not Achieved',
+	abandoned: 'Abandoned',
+	unknown: 'Unknown'
+};
+
+export const OUTCOME_COLORS: Record<string, string> = {
+	fully_achieved: '#10b981',
+	mostly_achieved: '#3b82f6',
+	partially_achieved: '#f59e0b',
+	not_achieved: '#ef4444',
+	abandoned: '#6b7280',
+	unknown: '#9ca3af'
+};
+
+export const HELPFULNESS_LABELS: Record<string, string> = {
+	essential: 'Essential',
+	very_helpful: 'Very Helpful',
+	helpful: 'Helpful',
+	slightly_helpful: 'Slightly Helpful',
+	not_helpful: 'Not Helpful'
+};
+
+export const HELPFULNESS_COLORS: Record<string, string> = {
+	essential: '#8b5cf6',
+	very_helpful: '#3b82f6',
+	helpful: '#10b981',
+	slightly_helpful: '#f59e0b',
+	not_helpful: '#ef4444'
+};
+
+export const SESSION_TYPE_LABELS: Record<string, string> = {
+	single_task: 'Single Task',
+	multi_task: 'Multi Task',
+	exploration: 'Exploration',
+	debugging: 'Debugging',
+	learning: 'Learning',
+	unknown: 'Unknown'
+};
+
+export const FRICTION_LABELS: Record<string, string> = {
+	tool_failures: 'Tool Failures',
+	context_loss: 'Context Loss',
+	misunderstanding: 'Misunderstanding',
+	slow_response: 'Slow Response',
+	permission_issues: 'Permission Issues',
+	unclear_instructions: 'Unclear Instructions',
+	repeated_attempts: 'Repeated Attempts',
+	scope_creep: 'Scope Creep'
+};

--- a/src/routes/insights/+page.svelte
+++ b/src/routes/insights/+page.svelte
@@ -1,0 +1,90 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import { Header } from '$lib/components/layout';
+	import InsightsReportViewer from '$lib/components/analytics/InsightsReportViewer.svelte';
+	import SessionQualityCards from '$lib/components/analytics/SessionQualityCards.svelte';
+	import FrictionTrendsChart from '$lib/components/analytics/FrictionTrendsChart.svelte';
+	import SessionSummaryList from '$lib/components/analytics/SessionSummaryList.svelte';
+	import { insightsStore } from '$lib/stores';
+	import { FileQuestion } from 'lucide-svelte';
+
+	onMount(() => {
+		insightsStore.load();
+	});
+
+	function handleRefresh() {
+		insightsStore.load();
+	}
+</script>
+
+<Header title="Insights" subtitle="Session quality, friction analysis, and Claude's insights report" />
+
+<div class="flex-1 overflow-auto p-6 space-y-6">
+	<!-- Report Section -->
+	{#if insightsStore.isLoadingReport}
+		<div class="flex items-center justify-center py-12">
+			<div
+				class="animate-spin w-8 h-8 border-2 border-primary-500 border-t-transparent rounded-full"
+			></div>
+		</div>
+	{:else if insightsStore.reportError}
+		<div
+			class="bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg p-4 text-red-700 dark:text-red-400"
+		>
+			{insightsStore.reportError}
+		</div>
+	{:else if insightsStore.reportExists && insightsStore.reportHtml}
+		<InsightsReportViewer
+			htmlContent={insightsStore.reportHtml}
+			filePath={insightsStore.reportFilePath}
+			onRefresh={handleRefresh}
+		/>
+	{:else}
+		<div
+			class="text-center py-10 bg-gray-50 dark:bg-gray-800/30 rounded-lg border-2 border-dashed border-gray-200 dark:border-gray-700"
+		>
+			<div class="text-gray-400 dark:text-gray-500">
+				<FileQuestion class="w-10 h-10 mx-auto mb-3 opacity-50" />
+				<p class="text-sm font-medium">No insights report found</p>
+				<p class="text-xs mt-1">
+					Run <code class="bg-gray-100 dark:bg-gray-700 px-1.5 py-0.5 rounded">/insights</code> in Claude Code to generate the report.
+				</p>
+			</div>
+		</div>
+	{/if}
+
+	<!-- Facets Section -->
+	{#if insightsStore.isLoadingFacets}
+		<div class="flex items-center justify-center py-12">
+			<div
+				class="animate-spin w-8 h-8 border-2 border-primary-500 border-t-transparent rounded-full"
+			></div>
+		</div>
+	{:else if insightsStore.facetsError}
+		<div
+			class="bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg p-4 text-red-700 dark:text-red-400"
+		>
+			{insightsStore.facetsError}
+		</div>
+	{:else if insightsStore.facetsExist && insightsStore.facets.length > 0}
+		<SessionQualityCards facets={insightsStore.facets} />
+
+		<div class="grid grid-cols-1 lg:grid-cols-2 gap-6">
+			<FrictionTrendsChart facets={insightsStore.facets} />
+			<SessionSummaryList facets={insightsStore.facets} />
+		</div>
+	{:else if !insightsStore.isLoadingReport}
+		<div
+			class="text-center py-10 bg-gray-50 dark:bg-gray-800/30 rounded-lg border-2 border-dashed border-gray-200 dark:border-gray-700"
+		>
+			<div class="text-gray-400 dark:text-gray-500">
+				<FileQuestion class="w-10 h-10 mx-auto mb-3 opacity-50" />
+				<p class="text-sm font-medium">No session quality data found</p>
+				<p class="text-xs mt-1">
+					Session facets are stored in <code class="bg-gray-100 dark:bg-gray-700 px-1.5 py-0.5 rounded">~/.claude/usage-data/facets/</code>
+				</p>
+				<p class="text-xs mt-1">Use Claude Code to generate session data, then refresh this page.</p>
+			</div>
+		</div>
+	{/if}
+</div>


### PR DESCRIPTION
## Summary
- Adds `/insights` route that surfaces Claude Code's `/insights` report via sandboxed iframe and per-session quality facets from `~/.claude/usage-data/`
- Includes donut charts for session outcome and helpfulness distributions, horizontal bar chart for friction categories, and expandable session summary accordion
- Graceful empty states when data files are missing, with guidance on how to generate them

## Test plan
- [ ] Navigate to `/insights` in sidebar — page loads with empty states if no data
- [ ] Place a `report.html` in `~/.claude/usage-data/` — iframe renders the report
- [ ] Place JSON files in `~/.claude/usage-data/facets/` — quality cards, friction chart, and session list render
- [ ] Click "Open in Browser" — report opens in system browser
- [ ] Click "Refresh" — both report and facets reload
- [ ] Verify dark mode styling across all components