### PR TITLE
Add cross-project comparison view

### DIFF
--- a/src/lib/components/comparison/ComparisonOverviewTable.svelte
+++ b/src/lib/components/comparison/ComparisonOverviewTable.svelte
@@ -1,0 +1,137 @@
+<script lang="ts">
+	import type { ProjectComparisonData } from '$lib/stores/comparisonStore.svelte';
+	import { formatCompactNumber, formatCost, formatModelName } from '$lib/types/usage';
+
+	type Props = {
+		data: ProjectComparisonData[];
+	};
+
+	let { data }: Props = $props();
+
+	function shortPath(path: string): string {
+		const parts = path.split(/[/\\]/);
+		return parts.slice(-2).join('/');
+	}
+
+	interface MetricRow {
+		label: string;
+		values: string[];
+		raw: number[];
+		highlightMax: boolean;
+	}
+
+	const rows = $derived.by((): MetricRow[] => {
+		if (data.length === 0) return [];
+
+		const sessions: MetricRow = {
+			label: 'Sessions',
+			values: data.map((d) => d.project.sessionCount.toLocaleString()),
+			raw: data.map((d) => d.project.sessionCount),
+			highlightMax: true
+		};
+
+		const totalTokens: MetricRow = {
+			label: 'Total Tokens',
+			values: data.map((d) => formatCompactNumber(d.totalTokens)),
+			raw: data.map((d) => d.totalTokens),
+			highlightMax: true
+		};
+
+		const inputTokens: MetricRow = {
+			label: 'Input Tokens',
+			values: data.map((d) => formatCompactNumber(d.project.totalInputTokens)),
+			raw: data.map((d) => d.project.totalInputTokens),
+			highlightMax: true
+		};
+
+		const outputTokens: MetricRow = {
+			label: 'Output Tokens',
+			values: data.map((d) => formatCompactNumber(d.project.totalOutputTokens)),
+			raw: data.map((d) => d.project.totalOutputTokens),
+			highlightMax: true
+		};
+
+		const cacheTokens: MetricRow = {
+			label: 'Cache Tokens',
+			values: data.map((d) =>
+				formatCompactNumber(d.project.totalCacheReadTokens + d.project.totalCacheCreationTokens)
+			),
+			raw: data.map((d) => d.project.totalCacheReadTokens + d.project.totalCacheCreationTokens),
+			highlightMax: true
+		};
+
+		const cost: MetricRow = {
+			label: 'Est. Cost',
+			values: data.map((d) => formatCost(d.estimatedCost)),
+			raw: data.map((d) => d.estimatedCost),
+			highlightMax: true
+		};
+
+		const models: MetricRow = {
+			label: 'Models',
+			values: data.map((d) => d.project.modelsUsed.map(formatModelName).join(', ') || 'N/A'),
+			raw: data.map((d) => d.project.modelsUsed.length),
+			highlightMax: false
+		};
+
+		const dateRange: MetricRow = {
+			label: 'Date Range',
+			values: data.map((d) => d.dateRange),
+			raw: data.map(() => 0),
+			highlightMax: false
+		};
+
+		return [sessions, totalTokens, inputTokens, outputTokens, cacheTokens, cost, models, dateRange];
+	});
+
+	function isMax(row: MetricRow, idx: number): boolean {
+		if (!row.highlightMax) return false;
+		const max = Math.max(...row.raw);
+		return max > 0 && row.raw[idx] === max;
+	}
+</script>
+
+<div class="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 p-4">
+	<h3 class="text-sm font-semibold text-gray-900 dark:text-white mb-4">Overview</h3>
+
+	<div class="overflow-x-auto">
+		<table class="w-full text-sm">
+			<thead>
+				<tr class="border-b border-gray-200 dark:border-gray-700">
+					<th class="text-left py-2 px-3 font-medium text-gray-500 dark:text-gray-400 min-w-[120px]">
+						Metric
+					</th>
+					{#each data as d}
+						<th class="text-right py-2 px-3 font-medium min-w-[100px]">
+							<div class="flex items-center justify-end gap-1.5">
+								<div class="w-2.5 h-2.5 rounded-full flex-shrink-0" style="background: {d.color}"></div>
+								<span class="text-gray-700 dark:text-gray-300 truncate max-w-[120px]">
+									{shortPath(d.project.inferredPath)}
+								</span>
+							</div>
+						</th>
+					{/each}
+				</tr>
+			</thead>
+			<tbody>
+				{#each rows as row}
+					<tr class="border-b border-gray-100 dark:border-gray-700/50">
+						<td class="py-2 px-3 text-gray-600 dark:text-gray-400 font-medium">
+							{row.label}
+						</td>
+						{#each row.values as value, i}
+							<td
+								class="text-right py-2 px-3
+									{isMax(row, i)
+									? 'font-bold text-primary-600 dark:text-primary-400'
+									: 'text-gray-700 dark:text-gray-300'}"
+							>
+								{value}
+							</td>
+						{/each}
+					</tr>
+				{/each}
+			</tbody>
+		</table>
+	</div>
+</div>

--- a/src/lib/components/comparison/ComparisonProjectSelector.svelte
+++ b/src/lib/components/comparison/ComparisonProjectSelector.svelte
@@ -1,0 +1,85 @@
+<script lang="ts">
+	import type { ProjectSummary } from '$lib/types';
+	import { projectTotalTokens } from '$lib/types/session';
+	import { formatCompactNumber } from '$lib/types/usage';
+	import { comparisonStore, PROJECT_COLORS } from '$lib/stores/comparisonStore.svelte';
+
+	type Props = {
+		projects: ProjectSummary[];
+	};
+
+	let { projects }: Props = $props();
+
+	function shortPath(path: string): string {
+		const parts = path.split(/[/\\]/);
+		return parts.slice(-2).join('/');
+	}
+
+	const selectedCount = $derived(comparisonStore.selectedFolders.size);
+
+	function colorForProject(folder: string): string | null {
+		const folders = [...comparisonStore.selectedFolders];
+		const idx = folders.indexOf(folder);
+		if (idx === -1) return null;
+		return PROJECT_COLORS[idx] ?? '#6b7280';
+	}
+</script>
+
+<div class="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 p-4">
+	<div class="flex items-center justify-between mb-3">
+		<h3 class="text-sm font-semibold text-gray-900 dark:text-white">
+			Select Projects ({selectedCount}/5 selected)
+		</h3>
+		{#if selectedCount > 0}
+			<button
+				onclick={() => comparisonStore.clearSelection()}
+				class="text-xs text-primary-500 hover:text-primary-600 font-medium"
+			>
+				Clear all
+			</button>
+		{/if}
+	</div>
+
+	<div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-2">
+		{#each projects as project}
+			{@const isSelected = comparisonStore.selectedFolders.has(project.folderName)}
+			{@const isDisabled = !isSelected && selectedCount >= 5}
+			{@const color = colorForProject(project.folderName)}
+			<button
+				onclick={() => comparisonStore.toggleProject(project.folderName)}
+				disabled={isDisabled}
+				class="w-full text-left px-3 py-2.5 rounded-lg transition-colors flex items-center gap-3
+					{isSelected
+					? 'bg-primary-50 border border-primary-200 dark:bg-primary-900/30 dark:border-primary-700'
+					: isDisabled
+						? 'opacity-40 cursor-not-allowed border border-transparent'
+						: 'hover:bg-gray-50 dark:hover:bg-gray-700/50 border border-transparent'}"
+			>
+				<!-- Color dot / checkbox -->
+				<div
+					class="w-4 h-4 rounded-full border-2 flex-shrink-0 flex items-center justify-center
+						{isSelected ? 'border-transparent' : 'border-gray-300 dark:border-gray-600'}"
+					style={isSelected ? `background: ${color}` : ''}
+				>
+					{#if isSelected}
+						<svg class="w-2.5 h-2.5 text-white" viewBox="0 0 12 12" fill="none">
+							<path d="M2 6l3 3 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
+						</svg>
+					{/if}
+				</div>
+
+				<div class="flex-1 min-w-0">
+					<p class="text-sm font-medium truncate {isSelected
+						? 'text-primary-700 dark:text-primary-300'
+						: 'text-gray-900 dark:text-white'}">
+						{shortPath(project.inferredPath)}
+					</p>
+					<div class="flex items-center gap-3 text-xs text-gray-500 dark:text-gray-400 mt-0.5">
+						<span>{project.sessionCount} sessions</span>
+						<span>{formatCompactNumber(projectTotalTokens(project))} tokens</span>
+					</div>
+				</div>
+			</button>
+		{/each}
+	</div>
+</div>

--- a/src/lib/components/comparison/CostComparisonChart.svelte
+++ b/src/lib/components/comparison/CostComparisonChart.svelte
@@ -1,0 +1,142 @@
+<script lang="ts">
+	import type { ProjectComparisonData } from '$lib/stores/comparisonStore.svelte';
+	import { formatCost } from '$lib/types/usage';
+
+	type Props = {
+		data: ProjectComparisonData[];
+	};
+
+	let { data }: Props = $props();
+
+	const chartWidth = 800;
+	const chartHeight = 300;
+	const padding = { top: 30, right: 20, bottom: 60, left: 70 };
+	const plotWidth = chartWidth - padding.left - padding.right;
+	const plotHeight = chartHeight - padding.top - padding.bottom;
+
+	const maxCost = $derived(Math.max(...data.map((d) => d.estimatedCost), 0.01));
+
+	const gridValues = $derived(
+		[0.2, 0.4, 0.6, 0.8, 1.0].map((f) => maxCost * f)
+	);
+
+	function shortPath(path: string): string {
+		const parts = path.split(/[/\\]/);
+		return parts.slice(-1)[0] ?? path;
+	}
+
+	const barWidth = $derived(data.length > 0 ? Math.min(80, (plotWidth / data.length) - 20) : 60);
+
+	function barX(i: number): number {
+		const groupWidth = plotWidth / data.length;
+		return padding.left + i * groupWidth + (groupWidth - barWidth) / 2;
+	}
+
+	function barY(val: number): number {
+		return padding.top + plotHeight - (val / maxCost) * plotHeight;
+	}
+
+	function barHeight(val: number): number {
+		return (val / maxCost) * plotHeight;
+	}
+
+	let tooltip = $state<{ x: number; y: number; label: string } | null>(null);
+
+	function handleBarHover(e: MouseEvent, d: ProjectComparisonData) {
+		const rect = (e.currentTarget as SVGElement).closest('svg')?.getBoundingClientRect();
+		if (!rect) return;
+		tooltip = {
+			x: e.clientX - rect.left,
+			y: e.clientY - rect.top - 10,
+			label: `${shortPath(d.project.inferredPath)}: ${formatCost(d.estimatedCost)}`
+		};
+	}
+
+	function handleBarLeave() {
+		tooltip = null;
+	}
+</script>
+
+<div class="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 p-4">
+	<h3 class="text-sm font-semibold text-gray-900 dark:text-white mb-4">Cost Comparison</h3>
+
+	{#if data.length === 0}
+		<div class="flex items-center justify-center py-12 text-gray-400 dark:text-gray-500">
+			Select projects to compare
+		</div>
+	{:else}
+		<div class="relative">
+			<svg viewBox="0 0 {chartWidth} {chartHeight}" class="w-full" preserveAspectRatio="xMidYMid meet">
+				<!-- Gridlines -->
+				{#each gridValues as gv}
+					<line
+						x1={padding.left}
+						y1={barY(gv)}
+						x2={chartWidth - padding.right}
+						y2={barY(gv)}
+						class="stroke-gray-200 dark:stroke-gray-700"
+						stroke-width="1"
+					/>
+					<text
+						x={padding.left - 8}
+						y={barY(gv) + 4}
+						text-anchor="end"
+						class="fill-gray-400 dark:fill-gray-500"
+						font-size="11"
+					>
+						{formatCost(gv)}
+					</text>
+				{/each}
+
+				<!-- Bars -->
+				{#each data as d, i}
+					<rect
+						x={barX(i)}
+						y={barY(d.estimatedCost)}
+						width={barWidth}
+						height={barHeight(d.estimatedCost)}
+						fill={d.color}
+						rx="3"
+						class="hover:opacity-80 transition-opacity cursor-pointer"
+						role="img"
+						onmouseenter={(e) => handleBarHover(e, d)}
+						onmouseleave={handleBarLeave}
+					/>
+
+					<!-- Cost label on top -->
+					<text
+						x={barX(i) + barWidth / 2}
+						y={barY(d.estimatedCost) - 6}
+						text-anchor="middle"
+						class="fill-gray-700 dark:fill-gray-300"
+						font-size="11"
+						font-weight="600"
+					>
+						{formatCost(d.estimatedCost)}
+					</text>
+
+					<!-- X-axis label -->
+					<text
+						x={barX(i) + barWidth / 2}
+						y={chartHeight - 10}
+						text-anchor="middle"
+						class="fill-gray-500 dark:fill-gray-400"
+						font-size="11"
+					>
+						{shortPath(d.project.inferredPath)}
+					</text>
+				{/each}
+			</svg>
+
+			<!-- Tooltip -->
+			{#if tooltip}
+				<div
+					class="absolute pointer-events-none bg-gray-900 dark:bg-gray-700 text-white text-xs rounded px-2 py-1 shadow-lg z-10"
+					style="left: {tooltip.x}px; top: {tooltip.y}px; transform: translate(-50%, -100%);"
+				>
+					{tooltip.label}
+				</div>
+			{/if}
+		</div>
+	{/if}
+</div>

--- a/src/lib/components/comparison/ModelMixComparison.svelte
+++ b/src/lib/components/comparison/ModelMixComparison.svelte
@@ -1,0 +1,90 @@
+<script lang="ts">
+	import type { ProjectComparisonData } from '$lib/stores/comparisonStore.svelte';
+	import { getModelColor, formatModelName } from '$lib/types/usage';
+
+	type Props = {
+		data: ProjectComparisonData[];
+		allModels: string[];
+	};
+
+	let { data, allModels }: Props = $props();
+
+	function shortPath(path: string): string {
+		const parts = path.split(/[/\\]/);
+		return parts.slice(-2).join('/');
+	}
+
+	interface ModelSummary {
+		modelId: string;
+		name: string;
+		color: string;
+		usedBy: number;
+	}
+
+	const modelSummaries = $derived.by((): ModelSummary[] => {
+		return allModels.map((modelId) => {
+			const usedBy = data.filter((d) => d.project.modelsUsed.includes(modelId)).length;
+			return {
+				modelId,
+				name: formatModelName(modelId),
+				color: getModelColor(modelId),
+				usedBy
+			};
+		}).sort((a, b) => b.usedBy - a.usedBy);
+	});
+</script>
+
+<div class="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 p-4">
+	<h3 class="text-sm font-semibold text-gray-900 dark:text-white mb-4">Model Mix</h3>
+
+	{#if data.length === 0}
+		<div class="flex items-center justify-center py-12 text-gray-400 dark:text-gray-500">
+			Select projects to compare
+		</div>
+	{:else}
+		<div class="space-y-3">
+			<!-- Per-project model pills -->
+			{#each data as d}
+				<div class="flex items-center gap-3">
+					<div class="flex items-center gap-1.5 min-w-[140px] flex-shrink-0">
+						<div class="w-2.5 h-2.5 rounded-full flex-shrink-0" style="background: {d.color}"></div>
+						<span class="text-sm text-gray-700 dark:text-gray-300 truncate">
+							{shortPath(d.project.inferredPath)}
+						</span>
+					</div>
+					<div class="flex flex-wrap gap-1.5">
+						{#each d.project.modelsUsed as modelId}
+							<span
+								class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium text-white"
+								style="background: {getModelColor(modelId)}"
+							>
+								{formatModelName(modelId)}
+							</span>
+						{/each}
+						{#if d.project.modelsUsed.length === 0}
+							<span class="text-xs text-gray-400 dark:text-gray-500">No models recorded</span>
+						{/if}
+					</div>
+				</div>
+			{/each}
+
+			<!-- Summary -->
+			{#if modelSummaries.length > 0}
+				<div class="border-t border-gray-200 dark:border-gray-700 pt-3 mt-3">
+					<p class="text-xs font-medium text-gray-500 dark:text-gray-400 mb-2">Summary</p>
+					<div class="space-y-1">
+						{#each modelSummaries as ms}
+							<div class="flex items-center gap-2 text-xs">
+								<div class="w-2 h-2 rounded-full flex-shrink-0" style="background: {ms.color}"></div>
+								<span class="text-gray-700 dark:text-gray-300 font-medium">{ms.name}</span>
+								<span class="text-gray-400 dark:text-gray-500">
+									used by {ms.usedBy}/{data.length} project{data.length !== 1 ? 's' : ''}
+								</span>
+							</div>
+						{/each}
+					</div>
+				</div>
+			{/if}
+		</div>
+	{/if}
+</div>

--- a/src/lib/components/comparison/TokenComparisonChart.svelte
+++ b/src/lib/components/comparison/TokenComparisonChart.svelte
@@ -1,0 +1,183 @@
+<script lang="ts">
+	import type { ProjectComparisonData } from '$lib/stores/comparisonStore.svelte';
+	import { formatCompactNumber } from '$lib/types/usage';
+
+	type Props = {
+		data: ProjectComparisonData[];
+	};
+
+	let { data }: Props = $props();
+
+	const TOKEN_COLORS = {
+		input: '#3b82f6',
+		output: '#8b5cf6',
+		cacheRead: '#10b981',
+		cacheWrite: '#f59e0b'
+	};
+
+	const TOKEN_LABELS: Record<string, string> = {
+		input: 'Input',
+		output: 'Output',
+		cacheRead: 'Cache Read',
+		cacheWrite: 'Cache Write'
+	};
+
+	const chartWidth = 800;
+	const chartHeight = 350;
+	const padding = { top: 20, right: 20, bottom: 60, left: 70 };
+	const plotWidth = chartWidth - padding.left - padding.right;
+	const plotHeight = chartHeight - padding.top - padding.bottom;
+
+	const tokenTypes = ['input', 'output', 'cacheRead', 'cacheWrite'] as const;
+
+	function getTokenValue(d: ProjectComparisonData, type: string): number {
+		switch (type) {
+			case 'input': return d.project.totalInputTokens;
+			case 'output': return d.project.totalOutputTokens;
+			case 'cacheRead': return d.project.totalCacheReadTokens;
+			case 'cacheWrite': return d.project.totalCacheCreationTokens;
+			default: return 0;
+		}
+	}
+
+	const maxValue = $derived.by(() => {
+		let max = 1;
+		for (const d of data) {
+			for (const t of tokenTypes) {
+				max = Math.max(max, getTokenValue(d, t));
+			}
+		}
+		return max;
+	});
+
+	const gridValues = $derived(
+		[0.2, 0.4, 0.6, 0.8, 1.0].map((f) => Math.round(maxValue * f))
+	);
+
+	function shortPath(path: string): string {
+		const parts = path.split(/[/\\]/);
+		return parts.slice(-1)[0] ?? path;
+	}
+
+	// Bar geometry
+	const groupWidth = $derived(data.length > 0 ? plotWidth / data.length : 100);
+	const barWidth = $derived(Math.max(4, (groupWidth - 20) / tokenTypes.length));
+
+	function barX(groupIdx: number, barIdx: number): number {
+		const groupStart = padding.left + groupIdx * groupWidth;
+		const barsWidth = tokenTypes.length * barWidth;
+		const groupOffset = (groupWidth - barsWidth) / 2;
+		return groupStart + groupOffset + barIdx * barWidth;
+	}
+
+	function barY(val: number): number {
+		return padding.top + plotHeight - (val / maxValue) * plotHeight;
+	}
+
+	function barHeight(val: number): number {
+		return (val / maxValue) * plotHeight;
+	}
+
+	let tooltip = $state<{ x: number; y: number; label: string; value: string } | null>(null);
+
+	function handleBarHover(e: MouseEvent, project: ProjectComparisonData, type: string) {
+		const rect = (e.currentTarget as SVGElement).closest('svg')?.getBoundingClientRect();
+		if (!rect) return;
+		const val = getTokenValue(project, type);
+		tooltip = {
+			x: e.clientX - rect.left,
+			y: e.clientY - rect.top - 10,
+			label: `${shortPath(project.project.inferredPath)} – ${TOKEN_LABELS[type]}`,
+			value: formatCompactNumber(val)
+		};
+	}
+
+	function handleBarLeave() {
+		tooltip = null;
+	}
+</script>
+
+<div class="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 p-4">
+	<h3 class="text-sm font-semibold text-gray-900 dark:text-white mb-2">Token Comparison</h3>
+
+	<!-- Legend -->
+	<div class="flex flex-wrap gap-4 mb-3">
+		{#each tokenTypes as type}
+			<div class="flex items-center gap-1.5">
+				<div class="w-3 h-3 rounded" style="background: {TOKEN_COLORS[type]}"></div>
+				<span class="text-xs text-gray-600 dark:text-gray-400">{TOKEN_LABELS[type]}</span>
+			</div>
+		{/each}
+	</div>
+
+	{#if data.length === 0}
+		<div class="flex items-center justify-center py-12 text-gray-400 dark:text-gray-500">
+			Select projects to compare
+		</div>
+	{:else}
+		<div class="relative">
+			<svg viewBox="0 0 {chartWidth} {chartHeight}" class="w-full" preserveAspectRatio="xMidYMid meet">
+				<!-- Gridlines -->
+				{#each gridValues as gv}
+					<line
+						x1={padding.left}
+						y1={barY(gv)}
+						x2={chartWidth - padding.right}
+						y2={barY(gv)}
+						class="stroke-gray-200 dark:stroke-gray-700"
+						stroke-width="1"
+					/>
+					<text
+						x={padding.left - 8}
+						y={barY(gv) + 4}
+						text-anchor="end"
+						class="fill-gray-400 dark:fill-gray-500"
+						font-size="11"
+					>
+						{formatCompactNumber(gv)}
+					</text>
+				{/each}
+
+				<!-- Bars -->
+				{#each data as d, gi}
+					{#each tokenTypes as type, bi}
+						{@const val = getTokenValue(d, type)}
+						<rect
+							x={barX(gi, bi)}
+							y={barY(val)}
+							width={barWidth - 1}
+							height={barHeight(val)}
+							fill={TOKEN_COLORS[type]}
+							rx="2"
+							class="hover:opacity-80 transition-opacity cursor-pointer"
+							role="img"
+							onmouseenter={(e) => handleBarHover(e, d, type)}
+							onmouseleave={handleBarLeave}
+						/>
+					{/each}
+
+					<!-- X-axis label -->
+					<text
+						x={padding.left + gi * groupWidth + groupWidth / 2}
+						y={chartHeight - 10}
+						text-anchor="middle"
+						class="fill-gray-500 dark:fill-gray-400"
+						font-size="11"
+					>
+						{shortPath(d.project.inferredPath)}
+					</text>
+				{/each}
+			</svg>
+
+			<!-- Tooltip -->
+			{#if tooltip}
+				<div
+					class="absolute pointer-events-none bg-gray-900 dark:bg-gray-700 text-white text-xs rounded px-2 py-1 shadow-lg z-10"
+					style="left: {tooltip.x}px; top: {tooltip.y}px; transform: translate(-50%, -100%);"
+				>
+					{tooltip.label}: {tooltip.value}
+				</div>
+			{/if}
+		</div>
+	{/if}
+</div>

--- a/src/lib/components/comparison/ToolUsageComparisonChart.svelte
+++ b/src/lib/components/comparison/ToolUsageComparisonChart.svelte
@@ -1,0 +1,145 @@
+<script lang="ts">
+	import type { ProjectComparisonData } from '$lib/stores/comparisonStore.svelte';
+	import { formatCompactNumber } from '$lib/types/usage';
+
+	type Props = {
+		data: ProjectComparisonData[];
+		tools: string[];
+	};
+
+	let { data, tools }: Props = $props();
+
+	function shortPath(path: string): string {
+		const parts = path.split(/[/\\]/);
+		return parts.slice(-1)[0] ?? path;
+	}
+
+	const labelWidth = 140;
+	const chartWidth = 800;
+	const padding = { top: 10, right: 20, bottom: 10, left: labelWidth };
+	const plotWidth = chartWidth - padding.left - padding.right;
+	const rowHeight = $derived(Math.max(24, 12 * data.length + 8));
+	const chartHeight = $derived(padding.top + padding.bottom + tools.length * rowHeight);
+
+	function getToolCount(d: ProjectComparisonData, tool: string): number {
+		return d.project.toolUsage[tool] ?? 0;
+	}
+
+	const maxCount = $derived.by(() => {
+		let max = 1;
+		for (const tool of tools) {
+			for (const d of data) {
+				max = Math.max(max, getToolCount(d, tool));
+			}
+		}
+		return max;
+	});
+
+	const barHeight = $derived(Math.max(6, Math.min(14, (rowHeight - 4) / data.length - 1)));
+
+	function barYOffset(toolIdx: number, projectIdx: number): number {
+		const rowTop = padding.top + toolIdx * rowHeight;
+		const barsHeight = data.length * (barHeight + 1);
+		const offset = (rowHeight - barsHeight) / 2;
+		return rowTop + offset + projectIdx * (barHeight + 1);
+	}
+
+	function barW(val: number): number {
+		return (val / maxCount) * plotWidth;
+	}
+
+	let tooltip = $state<{ x: number; y: number; label: string } | null>(null);
+
+	function handleBarHover(e: MouseEvent, d: ProjectComparisonData, tool: string) {
+		const rect = (e.currentTarget as SVGElement).closest('svg')?.getBoundingClientRect();
+		if (!rect) return;
+		const count = getToolCount(d, tool);
+		tooltip = {
+			x: e.clientX - rect.left,
+			y: e.clientY - rect.top - 10,
+			label: `${shortPath(d.project.inferredPath)} – ${tool}: ${formatCompactNumber(count)}`
+		};
+	}
+
+	function handleBarLeave() {
+		tooltip = null;
+	}
+</script>
+
+<div class="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 p-4">
+	<div class="flex items-center justify-between mb-3">
+		<h3 class="text-sm font-semibold text-gray-900 dark:text-white">Tool Usage (Top 10)</h3>
+		<!-- Legend -->
+		<div class="flex flex-wrap gap-3">
+			{#each data as d}
+				<div class="flex items-center gap-1.5">
+					<div class="w-2.5 h-2.5 rounded-full" style="background: {d.color}"></div>
+					<span class="text-xs text-gray-600 dark:text-gray-400">{shortPath(d.project.inferredPath)}</span>
+				</div>
+			{/each}
+		</div>
+	</div>
+
+	{#if tools.length === 0}
+		<div class="flex items-center justify-center py-12 text-gray-400 dark:text-gray-500">
+			No tool usage data
+		</div>
+	{:else}
+		<div class="relative">
+			<svg viewBox="0 0 {chartWidth} {chartHeight}" class="w-full" preserveAspectRatio="xMidYMid meet">
+				{#each tools as tool, ti}
+					<!-- Row background -->
+					{#if ti % 2 === 0}
+						<rect
+							x="0"
+							y={padding.top + ti * rowHeight}
+							width={chartWidth}
+							height={rowHeight}
+							class="fill-gray-50 dark:fill-gray-800/50"
+						/>
+					{/if}
+
+					<!-- Tool label -->
+					<text
+						x={labelWidth - 8}
+						y={padding.top + ti * rowHeight + rowHeight / 2 + 4}
+						text-anchor="end"
+						class="fill-gray-600 dark:fill-gray-400"
+						font-size="11"
+					>
+						{tool}
+					</text>
+
+					<!-- Bars per project -->
+					{#each data as d, pi}
+						{@const count = getToolCount(d, tool)}
+						{#if count > 0}
+							<rect
+								x={padding.left}
+								y={barYOffset(ti, pi)}
+								width={barW(count)}
+								height={barHeight}
+								fill={d.color}
+								rx="2"
+								class="hover:opacity-80 transition-opacity cursor-pointer"
+								role="img"
+								onmouseenter={(e) => handleBarHover(e, d, tool)}
+								onmouseleave={handleBarLeave}
+							/>
+						{/if}
+					{/each}
+				{/each}
+			</svg>
+
+			<!-- Tooltip -->
+			{#if tooltip}
+				<div
+					class="absolute pointer-events-none bg-gray-900 dark:bg-gray-700 text-white text-xs rounded px-2 py-1 shadow-lg z-10"
+					style="left: {tooltip.x}px; top: {tooltip.y}px; transform: translate(-50%, -100%);"
+				>
+					{tooltip.label}
+				</div>
+			{/if}
+		</div>
+	{/if}
+</div>

--- a/src/lib/components/layout/Sidebar.svelte
+++ b/src/lib/components/layout/Sidebar.svelte
@@ -1,8 +1,10 @@
 <script lang="ts">
 	import { page } from '$app/stores';
-	import { Library, FolderOpen, Settings, Bot, Store, Zap, Terminal, Sparkles, Layers, PanelBottom, Shield, FileText, Plug, BarChart3, TrendingUp, FolderSearch } from 'lucide-svelte';
+	import { Library, FolderOpen, Settings, Bot, Store, Zap, Terminal, Sparkles, Layers, PanelBottom, Shield, FileText, Plug, BarChart3, TrendingUp, FolderSearch, GitCompareArrows } from 'lucide-svelte';
 	import { onMount } from 'svelte';
 	import { getVersion } from '@tauri-apps/api/app';
+	import TodayUsageWidget from './TodayUsageWidget.svelte';
+	import { sessionStore } from '$lib/stores';
 
 	let appVersion = $state('');
 
@@ -11,6 +13,10 @@
 			appVersion = await getVersion();
 		} catch {
 			appVersion = '1.0.0';
+		}
+		// Load session projects for the usage widget
+		if (sessionStore.projects.length === 0) {
+			sessionStore.loadProjects();
 		}
 	});
 
@@ -60,7 +66,8 @@
 			items: [
 				{ href: '/analytics', label: 'Analytics', icon: BarChart3 },
 				{ href: '/insights', label: 'Insights', icon: TrendingUp },
-				{ href: '/sessions', label: 'Sessions', icon: FolderSearch }
+				{ href: '/sessions', label: 'Sessions', icon: FolderSearch },
+				{ href: '/comparison', label: 'Comparison', icon: GitCompareArrows }
 			]
 		}
 	];
@@ -107,6 +114,7 @@
 	</nav>
 
 	<div class="border-t border-gray-200 dark:border-gray-700 p-3">
+		<TodayUsageWidget />
 		<a
 			href="/settings"
 			class="flex items-center gap-3 px-3 py-2 rounded-lg text-sm font-medium transition-colors

--- a/src/lib/components/layout/TodayUsageWidget.svelte
+++ b/src/lib/components/layout/TodayUsageWidget.svelte
@@ -1,0 +1,70 @@
+<script lang="ts">
+	import { sessionStore } from '$lib/stores';
+	import { estimateSessionCost, formatCost, formatCompactNumber } from '$lib/types/usage';
+	import { Activity } from 'lucide-svelte';
+
+	const totalSessions = $derived(
+		sessionStore.projects.reduce((sum, p) => sum + p.sessionCount, 0)
+	);
+
+	const totalTokens = $derived(
+		sessionStore.projects.reduce(
+			(sum, p) => sum + p.totalInputTokens + p.totalOutputTokens,
+			0
+		)
+	);
+
+	const totalCost = $derived(
+		sessionStore.projects.reduce((sum, p) => {
+			return (
+				sum +
+				estimateSessionCost(
+					p.modelsUsed,
+					p.totalInputTokens,
+					p.totalOutputTokens,
+					p.totalCacheReadTokens,
+					p.totalCacheCreationTokens
+				)
+			);
+		}, 0)
+	);
+
+	const hasData = $derived(sessionStore.projects.length > 0);
+</script>
+
+{#if hasData}
+	<div class="px-3 py-2.5 mx-1.5 mb-2 rounded-lg bg-gray-50 dark:bg-gray-700/30">
+		<div class="flex items-center gap-1.5 mb-2">
+			<Activity class="w-3 h-3 text-gray-400 dark:text-gray-500" />
+			<span class="text-[10px] font-semibold uppercase tracking-wider text-gray-400 dark:text-gray-500">
+				Usage
+			</span>
+			{#if sessionStore.isLoadingProjects}
+				<div class="ml-auto w-1.5 h-1.5 rounded-full bg-primary-400 animate-pulse"></div>
+			{/if}
+		</div>
+		<div class="grid grid-cols-3 gap-y-1">
+			<div>
+				<span class="text-[10px] text-gray-400 dark:text-gray-500">Projects</span>
+				<p class="text-xs font-medium text-gray-700 dark:text-gray-300">
+					{sessionStore.projects.length}
+				</p>
+			</div>
+			<div>
+				<span class="text-[10px] text-gray-400 dark:text-gray-500">Sessions</span>
+				<p class="text-xs font-medium text-gray-700 dark:text-gray-300">
+					{totalSessions}
+				</p>
+			</div>
+			<div>
+				<span class="text-[10px] text-gray-400 dark:text-gray-500">Cost</span>
+				<p class="text-xs font-medium text-gray-700 dark:text-gray-300">
+					{totalCost > 0 ? formatCost(totalCost) : '—'}
+				</p>
+			</div>
+		</div>
+		<p class="text-[10px] text-gray-400 dark:text-gray-500 mt-1.5">
+			{formatCompactNumber(totalTokens)} tokens across all projects
+		</p>
+	</div>
+{/if}

--- a/src/lib/stores/comparisonStore.svelte.ts
+++ b/src/lib/stores/comparisonStore.svelte.ts
@@ -1,0 +1,100 @@
+import type { ProjectSummary } from '$lib/types';
+import { estimateSessionCost } from '$lib/types/usage';
+import { sessionStore } from './sessionStore.svelte';
+
+export const PROJECT_COLORS = ['#3b82f6', '#8b5cf6', '#f59e0b', '#ef4444', '#10b981'];
+
+export interface ProjectComparisonData {
+	project: ProjectSummary;
+	color: string;
+	totalTokens: number;
+	estimatedCost: number;
+	topTools: [string, number][];
+	dateRange: string;
+}
+
+class ComparisonStoreState {
+	selectedFolders = $state<Set<string>>(new Set());
+
+	selectedProjects = $derived.by((): ProjectSummary[] => {
+		return sessionStore.projects.filter((p) => this.selectedFolders.has(p.folderName));
+	});
+
+	comparisonData = $derived.by((): ProjectComparisonData[] => {
+		const folders = [...this.selectedFolders];
+		return this.selectedProjects.map((project) => {
+			const colorIndex = folders.indexOf(project.folderName);
+			const totalTokens = project.totalInputTokens + project.totalOutputTokens;
+			const estimatedCost = estimateSessionCost(
+				project.modelsUsed,
+				project.totalInputTokens,
+				project.totalOutputTokens,
+				project.totalCacheReadTokens,
+				project.totalCacheCreationTokens
+			);
+			const topTools = Object.entries(project.toolUsage)
+				.sort((a, b) => b[1] - a[1]);
+			const dateRange = formatDateRange(project.earliestSession, project.latestSession);
+
+			return {
+				project,
+				color: PROJECT_COLORS[colorIndex] ?? '#6b7280',
+				totalTokens,
+				estimatedCost,
+				topTools,
+				dateRange
+			};
+		});
+	});
+
+	allTools = $derived.by((): string[] => {
+		const totals: Record<string, number> = {};
+		for (const d of this.comparisonData) {
+			for (const [tool, count] of d.topTools) {
+				totals[tool] = (totals[tool] || 0) + count;
+			}
+		}
+		return Object.entries(totals)
+			.sort((a, b) => b[1] - a[1])
+			.slice(0, 10)
+			.map(([tool]) => tool);
+	});
+
+	allModels = $derived.by((): string[] => {
+		const modelSet = new Set<string>();
+		for (const d of this.comparisonData) {
+			for (const m of d.project.modelsUsed) {
+				modelSet.add(m);
+			}
+		}
+		return [...modelSet].sort();
+	});
+
+	toggleProject(folder: string) {
+		const next = new Set(this.selectedFolders);
+		if (next.has(folder)) {
+			next.delete(folder);
+		} else if (next.size < 5) {
+			next.add(folder);
+		}
+		this.selectedFolders = next;
+	}
+
+	clearSelection() {
+		this.selectedFolders = new Set();
+	}
+}
+
+function formatDateRange(earliest: string | null, latest: string | null): string {
+	const fmt = (iso: string | null) => {
+		if (!iso) return '?';
+		try {
+			return new Date(iso).toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
+		} catch {
+			return iso;
+		}
+	};
+	return `${fmt(earliest)} – ${fmt(latest)}`;
+}
+
+export const comparisonStore = new ComparisonStoreState();

--- a/src/lib/stores/index.ts
+++ b/src/lib/stores/index.ts
@@ -22,3 +22,4 @@ export { keybindingsLibrary } from './keybindingsLibrary.svelte';
 export { usageStore } from './usageStore.svelte';
 export { insightsStore } from './insightsStore.svelte';
 export { sessionStore } from './sessionStore.svelte';
+export { comparisonStore } from './comparisonStore.svelte';

--- a/src/routes/comparison/+page.svelte
+++ b/src/routes/comparison/+page.svelte
@@ -1,0 +1,87 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import { Header } from '$lib/components/layout';
+	import { sessionStore } from '$lib/stores';
+	import { comparisonStore } from '$lib/stores/comparisonStore.svelte';
+	import ComparisonProjectSelector from '$lib/components/comparison/ComparisonProjectSelector.svelte';
+	import ComparisonOverviewTable from '$lib/components/comparison/ComparisonOverviewTable.svelte';
+	import TokenComparisonChart from '$lib/components/comparison/TokenComparisonChart.svelte';
+	import CostComparisonChart from '$lib/components/comparison/CostComparisonChart.svelte';
+	import ToolUsageComparisonChart from '$lib/components/comparison/ToolUsageComparisonChart.svelte';
+	import ModelMixComparison from '$lib/components/comparison/ModelMixComparison.svelte';
+	import { GitCompareArrows, FileQuestion } from 'lucide-svelte';
+
+	onMount(() => {
+		if (sessionStore.projects.length === 0) {
+			sessionStore.loadProjects();
+		}
+	});
+
+	const hasEnoughSelected = $derived(comparisonStore.selectedFolders.size >= 2);
+</script>
+
+<Header title="Cross-Project Comparison" subtitle="Compare usage metrics across projects side-by-side" />
+
+<div class="flex-1 overflow-auto p-6 space-y-6">
+	{#if sessionStore.isLoadingProjects}
+		<div class="flex items-center justify-center py-20">
+			<div
+				class="animate-spin w-8 h-8 border-2 border-primary-500 border-t-transparent rounded-full"
+			></div>
+		</div>
+	{:else if sessionStore.projectsError}
+		<div
+			class="bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg p-4 text-red-700 dark:text-red-400"
+		>
+			{sessionStore.projectsError}
+		</div>
+	{:else if sessionStore.projects.length === 0}
+		<div
+			class="text-center py-16 bg-gray-50 dark:bg-gray-800/30 rounded-lg border-2 border-dashed border-gray-200 dark:border-gray-700"
+		>
+			<div class="text-gray-400 dark:text-gray-500">
+				<FileQuestion class="w-12 h-12 mx-auto mb-3 opacity-50" />
+				<p class="text-lg font-medium">No projects found</p>
+				<p class="text-sm mt-1">Use Claude Code to generate session data, then refresh this page.</p>
+			</div>
+		</div>
+	{:else}
+		<!-- Project Selector -->
+		<ComparisonProjectSelector projects={sessionStore.projects} />
+
+		{#if !hasEnoughSelected}
+			<div
+				class="text-center py-12 bg-gray-50 dark:bg-gray-800/30 rounded-lg border-2 border-dashed border-gray-200 dark:border-gray-700"
+			>
+				<div class="text-gray-400 dark:text-gray-500">
+					<GitCompareArrows class="w-10 h-10 mx-auto mb-3 opacity-50" />
+					<p class="text-sm font-medium">Select at least 2 projects to compare</p>
+					<p class="text-xs mt-1">
+						Choose 2–5 projects above to see side-by-side metrics
+					</p>
+				</div>
+			</div>
+		{:else}
+			<!-- Overview Table -->
+			<ComparisonOverviewTable data={comparisonStore.comparisonData} />
+
+			<!-- Token + Cost Charts -->
+			<div class="grid grid-cols-1 lg:grid-cols-2 gap-6">
+				<TokenComparisonChart data={comparisonStore.comparisonData} />
+				<CostComparisonChart data={comparisonStore.comparisonData} />
+			</div>
+
+			<!-- Tool Usage -->
+			<ToolUsageComparisonChart
+				data={comparisonStore.comparisonData}
+				tools={comparisonStore.allTools}
+			/>
+
+			<!-- Model Mix -->
+			<ModelMixComparison
+				data={comparisonStore.comparisonData}
+				allModels={comparisonStore.allModels}
+			/>
+		{/if}
+	{/if}
+</div>

--- a/src/routes/sessions/+page.svelte
+++ b/src/routes/sessions/+page.svelte
@@ -21,13 +21,7 @@
 	}
 </script>
 
-<Header title="Session Explorer" subtitle="Browse individual Claude Code sessions per project">
-	{#snippet children()}
-		<button onclick={handleRefresh} class="btn btn-ghost" title="Refresh data">
-			<RefreshCw class="w-4 h-4" />
-		</button>
-	{/snippet}
-</Header>
+<Header title="Session Explorer" subtitle="Browse individual Claude Code sessions per project" />
 
 <div class="flex-1 overflow-auto p-6 space-y-6">
 	{#if sessionStore.isLoadingProjects}
@@ -61,6 +55,17 @@
 	{:else}
 		<!-- Overview Cards -->
 		<ProjectOverviewCards projects={sessionStore.projects} />
+
+		<div class="flex items-center justify-end">
+			<button
+				onclick={handleRefresh}
+				class="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium text-gray-600 dark:text-gray-300 bg-gray-100 dark:bg-gray-700 hover:bg-gray-200 dark:hover:bg-gray-600 rounded-lg transition-colors"
+				title="Refresh sessions"
+			>
+				<RefreshCw class="w-3.5 h-3.5" />
+				Refresh
+			</button>
+		</div>
 
 		<!-- Project Selector + Tool Usage side by side on large screens -->
 		<div class="grid grid-cols-1 lg:grid-cols-2 gap-6 items-stretch">
@@ -132,6 +137,7 @@
 		{:else if sessionStore.sessionDetail}
 			<SessionDetailPanel
 				detail={sessionStore.sessionDetail}
+				sessionSummary={sessionStore.selectedSessionSummary}
 				onClose={() => sessionStore.clearSession()}
 			/>
 		{/if}


### PR DESCRIPTION
## Summary
- New `/comparison` route under Insights for side-by-side project usage comparison (2-5 projects)
- 6 comparison components: project selector, overview table, token chart, cost chart, tool usage chart, model mix
- Sidebar usage widget now uses live session data instead of stale stats-cache.json
- Moved page-specific refresh buttons below info cards on analytics and sessions pages

## Test plan
- [ ] Navigate to `/comparison` from the sidebar
- [ ] Select 2+ projects and verify all charts render
- [ ] Select 5 projects and confirm additional checkboxes are disabled
- [ ] Deselect below 2 and confirm placeholder message appears
- [ ] Verify sidebar usage widget shows live data (projects, sessions, cost)
- [ ] Check analytics and sessions pages have refresh button below info cards
- [ ] Verify dark mode rendering on all new components