### PR TITLE
Fix analytics page freeze from $derived vs $derived.by misuse

### DIFF
--- a/src/lib/components/analytics/DailyActivityChart.svelte
+++ b/src/lib/components/analytics/DailyActivityChart.svelte
@@ -50,7 +50,7 @@
 	}
 
 	// Show ~8 evenly spaced x-axis labels
-	const labelIndices = $derived(() => {
+	const labelIndices = $derived.by(() => {
 		if (data.length <= 8) return data.map((_, i) => i);
 		const step = Math.ceil(data.length / 8);
 		const indices: number[] = [];
@@ -162,7 +162,7 @@
 				{/each}
 
 				<!-- X-axis labels -->
-				{#each labelIndices() as li}
+				{#each labelIndices as li}
 					<text
 						x={barX(li) + barWidth / 2}
 						y={chartHeight - 8}

--- a/src/lib/components/analytics/DailyCostChart.svelte
+++ b/src/lib/components/analytics/DailyCostChart.svelte
@@ -38,7 +38,7 @@
 		return d.toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
 	}
 
-	const labelIndices = $derived(() => {
+	const labelIndices = $derived.by(() => {
 		if (data.length <= 8) return data.map((_, i) => i);
 		const step = Math.ceil(data.length / 8);
 		const indices: number[] = [];
@@ -141,7 +141,7 @@
 				{/each}
 
 				<!-- X-axis labels -->
-				{#each labelIndices() as li}
+				{#each labelIndices as li}
 					<text
 						x={barX(li) + barWidth / 2}
 						y={chartHeight - 8}

--- a/src/lib/components/analytics/DailyTokenChart.svelte
+++ b/src/lib/components/analytics/DailyTokenChart.svelte
@@ -43,7 +43,7 @@
 		return d.toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
 	}
 
-	const labelIndices = $derived(() => {
+	const labelIndices = $derived.by(() => {
 		if (data.length <= 8) return data.map((_, i) => i);
 		const step = Math.ceil(data.length / 8);
 		const indices: number[] = [];
@@ -145,7 +145,7 @@
 				{/each}
 
 				<!-- X-axis labels -->
-				{#each labelIndices() as li}
+				{#each labelIndices as li}
 					<text
 						x={barX(li) + barWidth / 2}
 						y={chartHeight - 8}


### PR DESCRIPTION
## Summary
- `$derived(() => {...})` in Svelte 5 returns a **closure**, not a computed value
- The three chart components (`DailyActivityChart`, `DailyTokenChart`, `DailyCostChart`) all used `$derived(() => {...})` for `labelIndices`, then called `labelIndices()` in the template
- Every render call produced a new array, triggering reactivity, causing an **infinite re-render loop** that hard-froze the browser
- Fixed by changing to `$derived.by(() => {...})` which executes the function and caches the result, and removing the `()` call syntax in templates

## Test plan
- [ ] Navigate to Analytics page — verify it loads without freezing
- [ ] Verify x-axis labels appear correctly on all three charts
- [ ] Switch date range and metric filters — verify charts update without lag