### PR TITLE
Add backup protection to all user file writes

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -657,7 +657,7 @@ dependencies = [
 
 [[package]]
 name = "claude-code-tool-manager"
-version = "3.8.0"
+version = "3.8.1"
 dependencies = [
  "anyhow",
  "axum",

--- a/src-tauri/src/services/agent_memory_writer.rs
+++ b/src-tauri/src/services/agent_memory_writer.rs
@@ -108,6 +108,7 @@ pub fn write_agent_memory(
         std::fs::create_dir_all(parent)?;
     }
 
+    crate::utils::backup::backup_file(&path)?;
     std::fs::write(&path, content)?;
     read_agent_memory(agent_name, scope, project_path)
 }

--- a/src-tauri/src/services/claude_settings.rs
+++ b/src-tauri/src/services/claude_settings.rs
@@ -111,6 +111,7 @@ fn write_settings_file(path: &Path, settings: &Value) -> Result<()> {
     if let Some(parent) = path.parent() {
         std::fs::create_dir_all(parent)?;
     }
+    crate::utils::backup::backup_file(path)?;
     let content = serde_json::to_string_pretty(settings)?;
     std::fs::write(path, content)?;
     Ok(())

--- a/src-tauri/src/services/command_writer.rs
+++ b/src-tauri/src/services/command_writer.rs
@@ -52,6 +52,7 @@ pub fn write_command_file(base_path: &Path, command: &Command) -> Result<()> {
     std::fs::create_dir_all(&commands_dir)?;
 
     let file_path = commands_dir.join(format!("{}.md", command.name));
+    crate::utils::backup::backup_file(&file_path)?;
     let content = generate_command_markdown(command);
     std::fs::write(file_path, content)?;
 
@@ -146,6 +147,7 @@ pub fn write_command_file_opencode(base_path: &Path, command: &Command) -> Resul
     std::fs::create_dir_all(&command_dir)?;
 
     let file_path = command_dir.join(format!("{}.md", command.name));
+    crate::utils::backup::backup_file(&file_path)?;
     let content = generate_command_markdown_opencode(command);
     std::fs::write(file_path, content)?;
 

--- a/src-tauri/src/services/config_writer.rs
+++ b/src-tauri/src/services/config_writer.rs
@@ -3,23 +3,7 @@ use anyhow::Result;
 use serde_json::{json, Map, Value};
 use std::path::Path;
 
-/// Create a backup of the config file before modifying it
-fn backup_config_file(path: &Path) -> Result<()> {
-    if !path.exists() {
-        return Ok(());
-    }
-
-    let backup_path = path.with_extension("json.bak");
-    std::fs::copy(path, &backup_path).map_err(|e| {
-        anyhow::anyhow!(
-            "Failed to create backup of {} before writing: {}",
-            path.display(),
-            e
-        )
-    })?;
-
-    Ok(())
-}
+use crate::utils::backup::backup_file as backup_config_file;
 
 type McpTuple = (
     String,         // name

--- a/src-tauri/src/services/hook_writer.rs
+++ b/src-tauri/src/services/hook_writer.rs
@@ -129,6 +129,8 @@ fn write_settings_file(path: &Path, settings: &Value) -> Result<()> {
         std::fs::create_dir_all(parent)?;
     }
 
+    crate::utils::backup::backup_file(path)?;
+
     let content = serde_json::to_string_pretty(settings)?;
     std::fs::write(path, content)?;
     Ok(())

--- a/src-tauri/src/services/keybindings_writer.rs
+++ b/src-tauri/src/services/keybindings_writer.rs
@@ -77,6 +77,7 @@ pub fn write_keybindings_to_path(path: &Path, kb: &KeybindingsFile) -> Result<()
             .collect(),
     };
 
+    crate::utils::backup::backup_file(path)?;
     let content = serde_json::to_string_pretty(&filtered)?;
     std::fs::write(path, content)?;
     Ok(())

--- a/src-tauri/src/services/memory_writer.rs
+++ b/src-tauri/src/services/memory_writer.rs
@@ -157,6 +157,7 @@ pub fn write_memory_file(
         std::fs::create_dir_all(parent)?;
     }
 
+    crate::utils::backup::backup_file(&path)?;
     std::fs::write(&path, content)?;
 
     // Read back the file info to return updated metadata

--- a/src-tauri/src/services/permission_writer.rs
+++ b/src-tauri/src/services/permission_writer.rs
@@ -49,6 +49,7 @@ fn write_settings_file(path: &Path, settings: &Value) -> Result<()> {
     if let Some(parent) = path.parent() {
         std::fs::create_dir_all(parent)?;
     }
+    crate::utils::backup::backup_file(path)?;
     let content = serde_json::to_string_pretty(settings)?;
     std::fs::write(path, content)?;
     Ok(())

--- a/src-tauri/src/services/rule_writer.rs
+++ b/src-tauri/src/services/rule_writer.rs
@@ -30,6 +30,7 @@ pub fn write_rule_file(base_path: &Path, rule: &Rule) -> Result<()> {
     std::fs::create_dir_all(&rules_dir)?;
 
     let file_path = rules_dir.join(format!("{}.md", rule.name));
+    crate::utils::backup::backup_file(&file_path)?;
     let content = generate_rule_markdown(rule);
     std::fs::write(file_path, content)?;
 

--- a/src-tauri/src/services/skill_writer.rs
+++ b/src-tauri/src/services/skill_writer.rs
@@ -79,6 +79,7 @@ pub fn write_skill_file(base_path: &Path, skill: &Skill) -> Result<()> {
     std::fs::create_dir_all(&skill_dir)?;
 
     let file_path = skill_dir.join("SKILL.md");
+    crate::utils::backup::backup_file(&file_path)?;
     let content = generate_skill_markdown(skill);
     std::fs::write(file_path, content)?;
 
@@ -132,6 +133,7 @@ pub fn write_skill_file_opencode(base_path: &Path, skill: &Skill) -> Result<()> 
     std::fs::create_dir_all(&agent_dir)?;
 
     let file_path = agent_dir.join(format!("{}.md", skill.name));
+    crate::utils::backup::backup_file(&file_path)?;
     let content = generate_skill_markdown(skill);
     std::fs::write(file_path, content)?;
 

--- a/src-tauri/src/services/spinner_verb_writer.rs
+++ b/src-tauri/src/services/spinner_verb_writer.rs
@@ -18,6 +18,7 @@ fn write_settings_file(path: &Path, settings: &Value) -> Result<()> {
     if let Some(parent) = path.parent() {
         std::fs::create_dir_all(parent)?;
     }
+    crate::utils::backup::backup_file(path)?;
     let content = serde_json::to_string_pretty(settings)?;
     std::fs::write(path, content)?;
     Ok(())

--- a/src-tauri/src/services/subagent_writer.rs
+++ b/src-tauri/src/services/subagent_writer.rs
@@ -88,6 +88,7 @@ pub fn write_subagent_file(base_path: &Path, subagent: &SubAgent) -> Result<()> 
     std::fs::create_dir_all(&agents_dir)?;
 
     let file_path = agents_dir.join(format!("{}.md", subagent.name));
+    crate::utils::backup::backup_file(&file_path)?;
     let content = generate_subagent_markdown(subagent);
     std::fs::write(file_path, content)?;
 
@@ -181,6 +182,7 @@ pub fn write_subagent_file_opencode(base_path: &Path, subagent: &SubAgent) -> Re
     std::fs::create_dir_all(&agents_dir)?;
 
     let file_path = agents_dir.join(format!("{}.md", subagent.name));
+    crate::utils::backup::backup_file(&file_path)?;
     let content = generate_subagent_markdown_opencode(subagent);
     std::fs::write(file_path, content)?;
 

--- a/src-tauri/src/utils/backup.rs
+++ b/src-tauri/src/utils/backup.rs
@@ -1,0 +1,103 @@
+use anyhow::Result;
+use std::path::Path;
+
+/// Create a `.bak` backup of a file before modifying it.
+///
+/// Returns `Ok(())` if the file does not exist (nothing to back up).
+/// The backup is placed alongside the original with `.bak` appended to the
+/// full filename (e.g. `settings.json` → `settings.json.bak`,
+/// `SKILL.md` → `SKILL.md.bak`).
+pub fn backup_file(path: &Path) -> Result<()> {
+    if !path.exists() {
+        return Ok(());
+    }
+
+    let file_name = path
+        .file_name()
+        .ok_or_else(|| {
+            anyhow::anyhow!("Cannot determine file name for backup: {}", path.display())
+        })?
+        .to_string_lossy();
+
+    let backup_name = format!("{}.bak", file_name);
+    let backup_path = path.with_file_name(backup_name);
+
+    std::fs::copy(path, &backup_path).map_err(|e| {
+        anyhow::anyhow!(
+            "Failed to create backup of {} before writing: {}",
+            path.display(),
+            e
+        )
+    })?;
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[test]
+    fn test_backup_nonexistent_file_succeeds() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("does-not-exist.json");
+        assert!(backup_file(&path).is_ok());
+    }
+
+    #[test]
+    fn test_backup_json_file() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("settings.json");
+        std::fs::write(&path, r#"{"key": "value"}"#).unwrap();
+
+        backup_file(&path).unwrap();
+
+        let backup = dir.path().join("settings.json.bak");
+        assert!(backup.exists());
+        assert_eq!(
+            std::fs::read_to_string(&backup).unwrap(),
+            r#"{"key": "value"}"#
+        );
+    }
+
+    #[test]
+    fn test_backup_md_file() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("SKILL.md");
+        std::fs::write(&path, "# My Skill").unwrap();
+
+        backup_file(&path).unwrap();
+
+        let backup = dir.path().join("SKILL.md.bak");
+        assert!(backup.exists());
+        assert_eq!(std::fs::read_to_string(&backup).unwrap(), "# My Skill");
+    }
+
+    #[test]
+    fn test_backup_local_settings_json() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("settings.local.json");
+        std::fs::write(&path, "{}").unwrap();
+
+        backup_file(&path).unwrap();
+
+        let backup = dir.path().join("settings.local.json.bak");
+        assert!(backup.exists());
+    }
+
+    #[test]
+    fn test_backup_overwrites_previous_backup() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("config.json");
+        let backup = dir.path().join("config.json.bak");
+
+        std::fs::write(&path, "v1").unwrap();
+        backup_file(&path).unwrap();
+        assert_eq!(std::fs::read_to_string(&backup).unwrap(), "v1");
+
+        std::fs::write(&path, "v2").unwrap();
+        backup_file(&path).unwrap();
+        assert_eq!(std::fs::read_to_string(&backup).unwrap(), "v2");
+    }
+}

--- a/src-tauri/src/utils/mod.rs
+++ b/src-tauri/src/utils/mod.rs
@@ -1,3 +1,4 @@
+pub mod backup;
 pub mod codex_paths;
 pub mod copilot_paths;
 pub mod cursor_paths;


### PR DESCRIPTION
## Summary
- Extracts `backup_config_file()` from `config_writer` into a shared `utils::backup::backup_file()` utility that handles any file extension (`.json`, `.md`, `.local.json`, etc.)
- Adds `backup_file()` calls before every `fs::write` to user-owned files across **all 12 writer modules** — ensuring a `.bak` copy exists before any modification
- Protects against data loss on first run and subsequent syncs

## Modules updated
| Module | Files protected |
|--------|----------------|
| hook_writer | `settings.json`, `settings.local.json` |
| claude_settings | `settings.json`, `settings.local.json` |
| permission_writer | `settings.json` |
| spinner_verb_writer | `settings.json` |
| keybindings_writer | `keybindings.json` |
| memory_writer | `CLAUDE.md`, `CLAUDE.local.md` |
| agent_memory_writer | agent memory `.md` files |
| skill_writer | `SKILL.md`, OpenCode agent `.md` |
| subagent_writer | agent `.md`, OpenCode agent `.md` |
| rule_writer | rule `.md` files |
| command_writer | command `.md`, OpenCode command `.md` |
| config_writer | now uses shared utility (was the only one with backup before) |

## Test plan
- [x] 5 new unit tests for `utils::backup::backup_file()` covering: nonexistent files, JSON backup, markdown backup, multi-extension files, backup overwrite
- [x] All 1991 Rust tests pass
- [x] All 1564 frontend tests pass
- [ ] Manual: edit a user file, trigger sync, verify `.bak` is created alongside the original