### PR TITLE
Fix: resolve gh CLI path for macOS GUI apps

### DIFF
--- a/src-tauri/src/commands/cloud_sync.rs
+++ b/src-tauri/src/commands/cloud_sync.rs
@@ -9,12 +9,29 @@ use tauri::State;
 
 // ─── Authentication ─────────────────────────────────────────────────────────
 
+/// Resolve the `gh` binary path.
+///
+/// macOS GUI apps inherit a minimal PATH that excludes Homebrew directories.
+/// This checks common install locations before falling back to bare `gh`.
+fn find_gh() -> std::path::PathBuf {
+    for candidate in &[
+        "/opt/homebrew/bin/gh", // Homebrew on Apple Silicon
+        "/usr/local/bin/gh",   // Homebrew on Intel / manual install
+        "/usr/bin/gh",         // System install
+    ] {
+        if std::path::Path::new(candidate).exists() {
+            return candidate.into();
+        }
+    }
+    "gh".into()
+}
+
 /// Get a GitHub token from the gh CLI
 #[tauri::command]
 pub async fn get_gh_cli_token() -> Result<String, String> {
     info!("[CloudSync] Getting token from gh CLI");
     tokio::task::spawn_blocking(|| {
-        let output = std::process::Command::new("gh")
+        let output = std::process::Command::new(find_gh())
             .args(["auth", "token"])
             .output()
             .map_err(|e| {
@@ -47,7 +64,7 @@ pub async fn get_gh_cli_token() -> Result<String, String> {
 /// Check if gh CLI is installed
 #[tauri::command]
 pub fn has_gh_cli() -> bool {
-    std::process::Command::new("gh")
+    std::process::Command::new(find_gh())
         .arg("--version")
         .output()
         .map(|o| o.status.success())


### PR DESCRIPTION
## Summary

- macOS GUI apps launched from Finder/Spotlight inherit a minimal PATH (`/usr/bin:/bin:/usr/sbin:/sbin`) that excludes Homebrew directories
- `Command::new("gh")` fails with `NotFound`, showing "gh CLI not installed" even when `gh` is installed and working from the terminal
- Adds a `find_gh()` helper that checks `/opt/homebrew/bin/gh` (Apple Silicon) and `/usr/local/bin/gh` (Intel) before falling back to bare `gh`

## Test plan

- [ ] Launch app from Finder on macOS with `gh` installed via Homebrew
- [ ] Verify Cloud Sync page shows "Connect" button instead of "gh CLI not installed"
- [ ] Verify `gh auth token` retrieval works after connecting

Fixes #194

🤖 Generated with [Claude Code](https://claude.com/claude-code)