### PR TITLE
Fix: paginate gist search to handle 100+ gists

### DIFF
--- a/src-tauri/src/services/gist_sync.rs
+++ b/src-tauri/src/services/gist_sync.rs
@@ -221,22 +221,33 @@ impl GistSyncService {
 
     /// Find existing sync gist or create a new one
     pub async fn find_or_create_gist(&self, token: &str) -> Result<(String, String)> {
-        // Search user's gists for our sync gist
-        let url = format!("{}/gists?per_page=100", self.api_base);
-        let response = self
-            .client
-            .get(&url)
-            .headers(self.auth_headers(token))
-            .send()
-            .await?;
+        // Search user's gists for our sync gist (paginated — GitHub caps at 100 per page)
+        let mut page = 1u32;
+        loop {
+            let url = format!("{}/gists?per_page=100&page={}", self.api_base, page);
+            let response = self
+                .client
+                .get(&url)
+                .headers(self.auth_headers(token))
+                .send()
+                .await?;
 
-        if response.status().is_success() {
+            if !response.status().is_success() {
+                break;
+            }
+
             let gists: Vec<GistResponse> = response.json().await?;
+            if gists.is_empty() {
+                break;
+            }
+
             for gist in &gists {
                 if gist.description.as_deref() == Some(GIST_DESCRIPTION) {
                     return Ok((gist.id.clone(), gist.html_url.clone()));
                 }
             }
+
+            page += 1;
         }
 
         // Not found — create a new private gist


### PR DESCRIPTION
## Summary

- `find_or_create_gist` only fetched the first 100 gists (GitHub API cap per page)
- Users with 100+ gists would never find their existing sync gist
- This caused a new gist to be created on every connect, with pushes going to ephemeral gists
- Adds page iteration so all gists are searched

## Test plan

- [ ] User with <100 gists: verify existing sync gist is found (no regression)
- [ ] User with 100+ gists: verify sync gist is found across pages
- [ ] New user: verify gist creation still works when no sync gist exists

Relates to #195

🤖 Generated with [Claude Code](https://claude.com/claude-code)