### PR TITLE
Fix: filter empty strings in sync auth status after disconnect

### DIFF
--- a/src-tauri/src/commands/cloud_sync.rs
+++ b/src-tauri/src/commands/cloud_sync.rs
@@ -109,10 +109,10 @@ pub async fn connect_cloud_sync(
 #[tauri::command]
 pub fn get_sync_auth_status(db: State<'_, Arc<Mutex<Database>>>) -> Result<SyncAuthStatus, String> {
     let db = db.lock().map_err(|e| e.to_string())?;
-    let token = db.get_setting("github_token");
-    let username = db.get_setting("sync_username");
-    let gist_id = db.get_setting("sync_gist_id");
-    let gist_url = db.get_setting("sync_gist_url");
+    let token = db.get_setting("github_token").filter(|s| !s.is_empty());
+    let username = db.get_setting("sync_username").filter(|s| !s.is_empty());
+    let gist_id = db.get_setting("sync_gist_id").filter(|s| !s.is_empty());
+    let gist_url = db.get_setting("sync_gist_url").filter(|s| !s.is_empty());
     let has_gh = has_gh_cli();
 
     Ok(SyncAuthStatus {


### PR DESCRIPTION
## Summary

- `disconnect_cloud_sync` sets `sync_gist_id` to `""` (no `delete_setting` method exists)
- `get_sync_auth_status` checked `gist_id.is_some()` without filtering empty strings
- `Some("")` passes the `is_some()` check, so `is_authenticated` stayed `true` after disconnect
- Adds `.filter(|s| !s.is_empty())` to all `get_setting` calls, matching the pattern already used in `get_sync_status`

## Test plan

- [ ] Connect cloud sync, then disconnect — verify auth status shows as disconnected
- [ ] Reconnect after disconnect — verify it works cleanly

Relates to #195

🤖 Generated with [Claude Code](https://claude.com/claude-code)