### PR TITLE
Fix: append .bak extension instead of replacing file extension

### DIFF
--- a/src-tauri/src/commands/cloud_sync.rs
+++ b/src-tauri/src/commands/cloud_sync.rs
@@ -16,8 +16,8 @@ use tauri::State;
 fn find_gh() -> std::path::PathBuf {
     for candidate in &[
         "/opt/homebrew/bin/gh", // Homebrew on Apple Silicon
-        "/usr/local/bin/gh",   // Homebrew on Intel / manual install
-        "/usr/bin/gh",         // System install
+        "/usr/local/bin/gh",    // Homebrew on Intel / manual install
+        "/usr/bin/gh",          // System install
     ] {
         if std::path::Path::new(candidate).exists() {
             return candidate.into();

--- a/src-tauri/src/services/gist_sync.rs
+++ b/src-tauri/src/services/gist_sync.rs
@@ -682,7 +682,12 @@ pub fn apply_pulled_payload(
                             }
                             // Back up existing file before overwriting
                             if claude_md_path.exists() {
-                                let backup = claude_md_path.with_extension("md.bak");
+                                let file_name = claude_md_path
+                                    .file_name()
+                                    .unwrap_or_default()
+                                    .to_string_lossy();
+                                let backup =
+                                    claude_md_path.with_file_name(format!("{}.bak", file_name));
                                 let _ = std::fs::copy(&claude_md_path, &backup);
                             }
                             if let Err(e) = std::fs::write(&claude_md_path, content) {

--- a/src-tauri/src/services/gist_sync.rs
+++ b/src-tauri/src/services/gist_sync.rs
@@ -558,7 +558,8 @@ pub fn apply_pulled_payload(
             }
             // Back up existing file before overwriting
             if path.exists() {
-                let backup = path.with_extension("md.bak");
+                let file_name = path.file_name().unwrap_or_default().to_string_lossy();
+                let backup = path.with_file_name(format!("{}.bak", file_name));
                 let _ = std::fs::copy(&path, &backup);
             }
             std::fs::write(&path, content)?;


### PR DESCRIPTION
## Summary

- `path.with_extension("md.bak")` replaces the existing extension rather than appending
- For `.md` files this works by coincidence (`CLAUDE.md` → `CLAUDE.md.bak`)
- For `.json` files it would produce `settings.md.bak` instead of `settings.json.bak`
- Uses `with_file_name(format!("{}.bak", file_name))` to properly append, matching the pattern in `utils/backup.rs`

## Test plan

- [ ] Pull with existing global CLAUDE.md — verify backup is created as `CLAUDE.md.bak`
- [ ] If testing with other file types, verify extension is preserved (e.g. `foo.json` → `foo.json.bak`)

Relates to #195

🤖 Generated with [Claude Code](https://claude.com/claude-code)