### PR TITLE
Fix: verify gist scope on connect (#195 bug 4)

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -657,7 +657,7 @@ dependencies = [
 
 [[package]]
 name = "claude-code-tool-manager"
-version = "3.8.1"
+version = "3.8.3"
 dependencies = [
  "anyhow",
  "axum",

--- a/src-tauri/src/commands/cloud_sync.rs
+++ b/src-tauri/src/commands/cloud_sync.rs
@@ -89,6 +89,13 @@ pub async fn connect_cloud_sync(
         .await
         .map_err(|e| format!("Failed to validate token: {}", e))?;
 
+    // Verify the token has `gist` scope before we try to use it, so the user
+    // gets a clear remediation message instead of a 403 at first push.
+    service
+        .verify_gist_scope(&token)
+        .await
+        .map_err(|e| e.to_string())?;
+
     // Find or create sync gist
     let (gist_id, gist_url) = service
         .find_or_create_gist(&token)

--- a/src-tauri/src/services/gist_sync.rs
+++ b/src-tauri/src/services/gist_sync.rs
@@ -219,6 +219,46 @@ impl GistSyncService {
         Ok(user.login)
     }
 
+    /// Verify the token carries the `gist` OAuth scope. Classic tokens (what
+    /// `gh auth token` returns) advertise granted scopes in the
+    /// `X-OAuth-Scopes` response header. Fine-grained PATs don't set this
+    /// header — in that case we can't verify upfront and fall through.
+    ///
+    /// Returns a user-facing error with the exact remediation command when
+    /// the scope is confirmed absent.
+    pub async fn verify_gist_scope(&self, token: &str) -> Result<()> {
+        let url = format!("{}/user", self.api_base);
+        let response = self
+            .client
+            .get(&url)
+            .headers(self.auth_headers(token))
+            .send()
+            .await?;
+
+        if !response.status().is_success() {
+            let status = response.status();
+            let text = response.text().await.unwrap_or_default();
+            return Err(anyhow!("GitHub API error {}: {}", status, text));
+        }
+
+        let Some(scopes_header) = response.headers().get("x-oauth-scopes") else {
+            // Fine-grained PAT or similar — can't verify, defer to API-level
+            // errors on the actual gist call.
+            return Ok(());
+        };
+
+        let scopes_str = scopes_header.to_str().unwrap_or("");
+        let has_gist = scopes_str.split(',').map(|s| s.trim()).any(|s| s == "gist");
+
+        if has_gist {
+            Ok(())
+        } else {
+            Err(anyhow!(
+                "GitHub token is missing the 'gist' scope. Run: gh auth refresh -h github.com -s gist"
+            ))
+        }
+    }
+
     /// Find existing sync gist or create a new one
     pub async fn find_or_create_gist(&self, token: &str) -> Result<(String, String)> {
         // Search user's gists for our sync gist (paginated — GitHub caps at 100 per page)
@@ -781,6 +821,83 @@ mod tests {
 
         let service = GistSyncService::with_base_url(mock_server.uri());
         let result = service.get_authenticated_user("bad-token").await;
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("401"));
+    }
+
+    #[tokio::test]
+    async fn test_verify_gist_scope_present() {
+        let mock_server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/user"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("X-OAuth-Scopes", "repo, gist, read:org")
+                    .set_body_json(serde_json::json!({ "login": "testuser" })),
+            )
+            .mount(&mock_server)
+            .await;
+
+        let service = GistSyncService::with_base_url(mock_server.uri());
+        let result = service.verify_gist_scope("test-token").await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_verify_gist_scope_missing() {
+        let mock_server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/user"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("X-OAuth-Scopes", "repo, read:org")
+                    .set_body_json(serde_json::json!({ "login": "testuser" })),
+            )
+            .mount(&mock_server)
+            .await;
+
+        let service = GistSyncService::with_base_url(mock_server.uri());
+        let err = service.verify_gist_scope("test-token").await.unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("'gist' scope"), "got: {}", msg);
+        assert!(msg.contains("gh auth refresh"), "got: {}", msg);
+    }
+
+    #[tokio::test]
+    async fn test_verify_gist_scope_header_absent() {
+        // Fine-grained PATs don't emit X-OAuth-Scopes — we should not block.
+        let mock_server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/user"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_json(serde_json::json!({ "login": "testuser" })),
+            )
+            .mount(&mock_server)
+            .await;
+
+        let service = GistSyncService::with_base_url(mock_server.uri());
+        let result = service.verify_gist_scope("test-token").await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_verify_gist_scope_unauthorized() {
+        let mock_server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/user"))
+            .respond_with(ResponseTemplate::new(401).set_body_json(serde_json::json!({
+                "message": "Bad credentials"
+            })))
+            .mount(&mock_server)
+            .await;
+
+        let service = GistSyncService::with_base_url(mock_server.uri());
+        let result = service.verify_gist_scope("bad-token").await;
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("401"));
     }


### PR DESCRIPTION
## Summary

Closes the last remaining bug from #195: `connect_cloud_sync` accepted any token `gh auth token` returned, so users without the `gist` scope got a generic 403 on first push instead of a helpful message at connect time.

Now verifies the `gist` scope via the `X-OAuth-Scopes` response header on `GET /user` before storing credentials. If the scope is absent, the error names the exact remediation: \`gh auth refresh -h github.com -s gist\`.

Fine-grained PATs don't emit `X-OAuth-Scopes`, so in that case we fall through (the API-level error will still surface later on the actual gist call).

## What changed

- `services/gist_sync.rs` — added `verify_gist_scope(token)` + 4 tests (scope present / scope missing / header absent / 401).
- `commands/cloud_sync.rs` — call `verify_gist_scope` in `connect_cloud_sync` after `get_authenticated_user`, before `find_or_create_gist`.
- `Cargo.lock` — refresh to match `Cargo.toml` version (was stale at 3.8.1, now 3.8.3).

## Test plan

- [x] \`cargo test --lib gist_sync\` — 14/14 pass (4 new).
- [x] \`cargo fmt --check\` clean.
- [ ] Manual: disconnect gh, re-auth without gist scope (\`gh auth refresh -s repo\`), click Connect — should see the scope error with remediation, not a 403 later.

## Bugs 1–3 from #195 already landed

- Bug 1 (pagination): commit \`511c98c\`
- Bug 2 (disconnect empty-string check): commit \`815cf4c\`
- Bug 3 (backup extension): commits \`1c55739\`, \`f74448e\`

Once this merges, #195 can close.

🤖 Generated with [Claude Code](https://claude.com/claude-code)