### PR TITLE
fix: writers emit tags as JSON array frontmatter (skill/command/subagent)

### DIFF
--- a/src-tauri/src/services/command_writer.rs
+++ b/src-tauri/src/services/command_writer.rs
@@ -41,6 +41,12 @@ pub(crate) fn generate_command_markdown(command: &Command) -> String {
         }
     }
 
+    if let Some(ref tags) = command.tags {
+        if !tags.is_empty() {
+            frontmatter.push_str(&format!("tags: {}\n", serde_json::to_string(tags).unwrap()));
+        }
+    }
+
     frontmatter.push_str("---\n\n");
     format!("{}{}", frontmatter, command.content)
 }
@@ -265,6 +271,31 @@ mod tests {
         assert!(!md.contains("argument-hint:"));
         assert!(!md.contains("model:"));
         assert!(md.contains("Minimal content."));
+    }
+
+    #[test]
+    fn test_generate_command_markdown_emits_tags_as_json_array() {
+        // Mirrors the rule_writer fix: `tags` is read from the DB via
+        // `serde_json::from_str`, so if a scanner ever ingests a command
+        // frontmatter the value must be valid JSON, not comma-joined.
+        // Also pins against silent-drop: previously `command.tags` was not
+        // written to frontmatter at all.
+        let mut command = sample_minimal_command();
+        command.tags = Some(vec!["triage".to_string(), "prs".to_string()]);
+
+        let md = generate_command_markdown(&command);
+
+        assert!(md.contains("tags: [\"triage\",\"prs\"]\n"));
+    }
+
+    #[test]
+    fn test_generate_command_markdown_omits_empty_tags() {
+        let mut command = sample_minimal_command();
+        command.tags = Some(vec![]);
+
+        let md = generate_command_markdown(&command);
+
+        assert!(!md.contains("tags:"));
     }
 
     // =========================================================================

--- a/src-tauri/src/services/skill_writer.rs
+++ b/src-tauri/src/services/skill_writer.rs
@@ -68,6 +68,12 @@ pub(crate) fn generate_skill_markdown(skill: &Skill) -> String {
         }
     }
 
+    if let Some(ref tags) = skill.tags {
+        if !tags.is_empty() {
+            frontmatter.push_str(&format!("tags: {}\n", serde_json::to_string(tags).unwrap()));
+        }
+    }
+
     frontmatter.push_str("---\n\n");
     format!("{}{}", frontmatter, skill.content)
 }
@@ -269,6 +275,31 @@ mod tests {
         let md = generate_skill_markdown(&skill);
 
         assert!(md.contains("name: minimal\n"));
+    }
+
+    #[test]
+    fn test_generate_skill_markdown_emits_tags_as_json_array() {
+        // Mirrors the rule_writer fix: `tags` is read from the DB via
+        // `serde_json::from_str`, so if a scanner ever ingests a skill
+        // frontmatter the value must be valid JSON, not comma-joined.
+        // Also pins against silent-drop: previously `skill.tags` was not
+        // written to frontmatter at all.
+        let mut skill = sample_minimal_skill();
+        skill.tags = Some(vec!["refactor".to_string(), "typescript".to_string()]);
+
+        let md = generate_skill_markdown(&skill);
+
+        assert!(md.contains("tags: [\"refactor\",\"typescript\"]\n"));
+    }
+
+    #[test]
+    fn test_generate_skill_markdown_omits_empty_tags() {
+        let mut skill = sample_minimal_skill();
+        skill.tags = Some(vec![]);
+
+        let md = generate_skill_markdown(&skill);
+
+        assert!(!md.contains("tags:"));
     }
 
     // =========================================================================

--- a/src-tauri/src/services/subagent_writer.rs
+++ b/src-tauri/src/services/subagent_writer.rs
@@ -78,6 +78,12 @@ pub(crate) fn generate_subagent_markdown(subagent: &SubAgent) -> String {
         }
     }
 
+    if let Some(ref tags) = subagent.tags {
+        if !tags.is_empty() {
+            frontmatter.push_str(&format!("tags: {}\n", serde_json::to_string(tags).unwrap()));
+        }
+    }
+
     frontmatter.push_str("---\n\n");
     format!("{}{}", frontmatter, subagent.content)
 }
@@ -318,6 +324,31 @@ mod tests {
         assert!(!md.contains("permissionMode:"));
         assert!(!md.contains("skills:"));
         assert!(md.contains("---\n\nYou are a helpful assistant."));
+    }
+
+    #[test]
+    fn test_generate_subagent_markdown_emits_tags_as_json_array() {
+        // Mirrors the rule_writer fix: `tags` is read from the DB via
+        // `serde_json::from_str`, so if a scanner ever ingests a subagent
+        // frontmatter the value must be valid JSON, not comma-joined.
+        // Also pins against silent-drop: previously `subagent.tags` was not
+        // written to frontmatter at all.
+        let mut subagent = sample_minimal_subagent();
+        subagent.tags = Some(vec!["review".to_string(), "quality".to_string()]);
+
+        let md = generate_subagent_markdown(&subagent);
+
+        assert!(md.contains("tags: [\"review\",\"quality\"]\n"));
+    }
+
+    #[test]
+    fn test_generate_subagent_markdown_omits_empty_tags() {
+        let mut subagent = sample_minimal_subagent();
+        subagent.tags = Some(vec![]);
+
+        let md = generate_subagent_markdown(&subagent);
+
+        assert!(!md.contains("tags:"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Follow-up to #200. Closes the same round-trip failure class that PR caught for `rule_writer`, applied to the three other flat-`.md` writers.

The DB readers for skills, commands, and sub-agents deserialise the `tags` column via `serde_json::from_str` — see [`db/schema.rs:1727`](https://github.com/tylergraydev/claude-code-tool-manager/blob/main/src-tauri/src/db/schema.rs#L1727), [`:1860`](https://github.com/tylergraydev/claude-code-tool-manager/blob/main/src-tauri/src/db/schema.rs#L1860), [`:2009`](https://github.com/tylergraydev/claude-code-tool-manager/blob/main/src-tauri/src/db/schema.rs#L2009). The three matching writers silently dropped `tags` from frontmatter entirely. No live corruption today because no scanner re-ingests these primitives — but given #200 closed the "every primitive has a disk scanner except rules" asymmetry, it's reasonable to assume scanners for skills/commands/agents will follow. At that point, disk round-trip would either lose tags or (if anyone ships a comma-joined stopgap) silently corrupt them the same way rule_writer did pre-#200.

## Changes

| File | Change |
|---|---|
| `src-tauri/src/services/skill_writer.rs` | `generate_skill_markdown` emits `tags: <json-array>` when non-empty |
| `src-tauri/src/services/command_writer.rs` | `generate_command_markdown` emits `tags: <json-array>` when non-empty |
| `src-tauri/src/services/subagent_writer.rs` | `generate_subagent_markdown` emits `tags: <json-array>` when non-empty |

Each writer gains two tests: one pins the JSON-array emission shape, one pins the empty-vec skip path.

No schema change, no new dependency, no public-API change.

## Test plan

- [x] `cargo fmt --check` passes
- [x] `cargo test --lib` — full suite passes locally, 6 new tests added
- [x] `cargo test --lib writer` — 299/299 writer tests pass
- [ ] End-to-end: UI-created skill/command/subagent with tags round-trips to disk as JSON-array form (no live scanner to ingest yet, so this is visual verification only)

## Not in scope (intentionally)

`paths`, `allowed_tools`, `tools`, `skills`, `disallowed_tools` in these same writers still use comma-joined form. Same latent round-trip shape, but expanding this PR would:
- Bloat the diff from three symmetric 7-line emissions to a dozen heterogeneous changes
- Require deciding a canonical form before the scanners exist (e.g. allowed_tools space-separated? comma with CSV quoting?), which is better decided *with* the scanner PR that'll consume the format

Separate PRs when their scanners land.

## Relation to #200

This PR branches from `main` (not from the #200 branch) — zero file overlap with #200's diff. Safe to review and merge independently in either order.
