### PR TITLE
fix: prevent sync config from destroying externally-managed configs

### DIFF
--- a/src-tauri/src/commands/projects.rs
+++ b/src-tauri/src/commands/projects.rs
@@ -119,6 +119,7 @@ pub fn add_project(
     db: State<'_, Arc<Mutex<Database>>>,
     project: CreateProjectRequest,
 ) -> Result<Project, String> {
+    use crate::services::scanner;
     use crate::utils::paths::get_claude_paths;
 
     info!(
@@ -127,9 +128,9 @@ pub fn add_project(
     );
     let db = db.lock().map_err(|e| e.to_string())?;
 
-    // Check if .claude/.mcp.json exists
+    // Check if .mcp.json exists (project root is the standard location)
     let project_path = PathBuf::from(&project.path);
-    let mcp_file = project_path.join(".claude").join(".mcp.json");
+    let mcp_file = project_path.join(".mcp.json");
     let settings_file = project_path.join(".claude").join("settings.local.json");
 
     let has_mcp_file = mcp_file.exists();
@@ -150,11 +151,26 @@ pub fn add_project(
 
     let id = db.conn().last_insert_rowid();
 
+    // Import MCPs from existing .mcp.json so they show up in the UI
+    let imported_mcps = if has_mcp_file {
+        scanner::import_mcps_from_project_mcp_json(&db, id, &project.path)
+            .map_err(|e| e.to_string())?
+    } else {
+        0
+    };
+    info!(
+        "[Projects] Imported {} MCPs from .mcp.json for project id={}",
+        imported_mcps, id
+    );
+
     // Register project in claude.json (even with no MCPs)
     if let Ok(paths) = get_claude_paths() {
         let empty_mcps: Vec<config_writer::McpWithEnabledTuple> = vec![];
         let _ = config_writer::write_project_to_claude_json(&paths, &project.path, &empty_mcps);
     }
+
+    // Fetch assigned MCPs to return in the response
+    let assigned_mcps = get_project_assigned_mcps(&db, id);
 
     Ok(Project {
         id,
@@ -167,7 +183,7 @@ pub fn add_project(
         is_favorite: false,
         created_at: chrono::Utc::now().to_rfc3339(),
         updated_at: chrono::Utc::now().to_rfc3339(),
-        assigned_mcps: vec![],
+        assigned_mcps,
     })
 }
 
@@ -603,6 +619,48 @@ pub fn toggle_project_favorite(
     toggle_project_favorite_in_db(&db, id, favorite)
 }
 
+#[tauri::command]
+pub fn open_folder(path: String) -> Result<(), String> {
+    #[cfg(target_os = "windows")]
+    {
+        std::process::Command::new("explorer")
+            .arg(&path)
+            .spawn()
+            .map_err(|e| e.to_string())?;
+    }
+    #[cfg(target_os = "macos")]
+    {
+        std::process::Command::new("open")
+            .arg(&path)
+            .spawn()
+            .map_err(|e| e.to_string())?;
+    }
+    #[cfg(target_os = "linux")]
+    {
+        std::process::Command::new("xdg-open")
+            .arg(&path)
+            .spawn()
+            .map_err(|e| e.to_string())?;
+    }
+    Ok(())
+}
+
+#[tauri::command]
+pub fn update_project_editor_type(
+    db: State<'_, Arc<Mutex<Database>>>,
+    project_id: i64,
+    editor_type: String,
+) -> Result<(), String> {
+    let db = db.lock().map_err(|e| e.to_string())?;
+    db.conn()
+        .execute(
+            "UPDATE projects SET editor_type = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ?",
+            params![editor_type, project_id],
+        )
+        .map_err(|e| e.to_string())?;
+    Ok(())
+}
+
 /// Toggle project favorite status in the database
 pub(crate) fn toggle_project_favorite_in_db(
     db: &Database,
@@ -616,6 +674,39 @@ pub(crate) fn toggle_project_favorite_in_db(
         )
         .map_err(|e| e.to_string())?;
     Ok(())
+}
+
+/// Get assigned MCPs for a project from the database
+fn get_project_assigned_mcps(db: &Database, project_id: i64) -> Vec<ProjectMcp> {
+    let result: Result<Vec<ProjectMcp>, rusqlite::Error> = (|| {
+        let mut stmt = db.conn().prepare(
+            "SELECT pm.id, pm.mcp_id, pm.is_enabled, pm.env_overrides, pm.display_order,
+                    m.id, m.name, m.description, m.type, m.command, m.args, m.url, m.headers, m.env,
+                    m.icon, m.tags, m.source, m.source_path, m.is_enabled_global, m.is_favorite, m.created_at, m.updated_at
+             FROM project_mcps pm
+             JOIN mcps m ON pm.mcp_id = m.id
+             WHERE pm.project_id = ?
+             ORDER BY pm.display_order",
+        )?;
+
+        let mcps = stmt
+            .query_map([project_id], |row| {
+                Ok(ProjectMcp {
+                    id: row.get(0)?,
+                    mcp_id: row.get(1)?,
+                    is_enabled: row.get::<_, i32>(2)? != 0,
+                    env_overrides: parse_json_map(row.get(3)?),
+                    display_order: row.get(4)?,
+                    mcp: row_to_mcp(row, 5)?,
+                })
+            })?
+            .filter_map(|r| r.ok())
+            .collect();
+
+        Ok(mcps)
+    })();
+
+    result.unwrap_or_default()
 }
 
 /// Assign an MCP to a project in the database

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -221,6 +221,8 @@ pub fn run() {
             commands::projects::toggle_project_mcp,
             commands::projects::toggle_project_favorite,
             commands::projects::sync_project_config,
+            commands::projects::open_folder,
+            commands::projects::update_project_editor_type,
             // Global Settings Commands
             commands::config::get_global_mcps,
             commands::config::add_global_mcp,

--- a/src-tauri/src/services/codex_config.rs
+++ b/src-tauri/src/services/codex_config.rs
@@ -211,6 +211,11 @@ pub fn write_codex_config(path: &Path, mcps: &[McpTuple]) -> Result<()> {
         )
     })?;
 
+    // Skip overwrite when DB has no MCPs — preserves externally-managed configs
+    if mcps.is_empty() {
+        return Ok(());
+    }
+
     // Create or get mcp_servers table
     if doc.get("mcp_servers").is_none() {
         doc["mcp_servers"] = Item::Table(Table::new());

--- a/src-tauri/src/services/config_writer.rs
+++ b/src-tauri/src/services/config_writer.rs
@@ -305,8 +305,13 @@ pub fn write_project_to_claude_json(
         }
     }
 
-    project["mcpServers"] = Value::Object(mcp_servers);
-    project["disabledMcpServers"] = json!(disabled_mcps);
+    // Only update mcpServers if DB has servers — preserves externally-managed configs
+    if !mcp_servers.is_empty() {
+        project["mcpServers"] = Value::Object(mcp_servers);
+    }
+    if !disabled_mcps.is_empty() {
+        project["disabledMcpServers"] = json!(disabled_mcps);
+    }
 
     // Back up the existing file before modifying it
     backup_config_file(&paths.claude_json)?;
@@ -610,11 +615,12 @@ mod tests {
         let content = std::fs::read_to_string(&config_path).unwrap();
         let parsed: Value = serde_json::from_str(&content).unwrap();
 
-        // mcpServers should be empty (DB has none)
+        // mcpServers should be preserved (DB has none, so we don't overwrite)
         let servers = parsed.get("mcpServers").unwrap().as_object().unwrap();
-        assert_eq!(servers.len(), 0);
+        assert_eq!(servers.len(), 1);
+        assert!(servers.contains_key("external-server"));
 
-        // But the file should still have valid structure and preserve other keys
+        // Other keys should also be preserved
         assert_eq!(parsed.get("someOtherConfig").unwrap(), true);
     }
 

--- a/src-tauri/src/services/config_writer.rs
+++ b/src-tauri/src/services/config_writer.rs
@@ -113,9 +113,12 @@ pub fn write_project_config(project_path: &Path, mcps: &[McpTuple]) -> Result<()
     };
 
     // Merge DB-managed mcpServers into existing config
+    // Skip overwrite when DB has no servers — preserves externally-managed .mcp.json
     let mcp_config = generate_mcp_config(mcps);
-    if let Some(servers) = mcp_config.get("mcpServers") {
-        existing["mcpServers"] = servers.clone();
+    if let Some(Value::Object(servers)) = mcp_config.get("mcpServers") {
+        if !servers.is_empty() {
+            existing["mcpServers"] = Value::Object(servers.clone());
+        }
     }
 
     // Back up existing file before writing
@@ -143,9 +146,12 @@ pub fn write_global_config(paths: &ClaudePathsInternal, mcps: &[McpTuple]) -> Re
     };
 
     // Build mcpServers object
+    // Skip overwrite when DB has no servers — preserves externally-managed config
     let mcp_config = generate_mcp_config(mcps);
-    if let Some(servers) = mcp_config.get("mcpServers") {
-        claude_json["mcpServers"] = servers.clone();
+    if let Some(Value::Object(servers)) = mcp_config.get("mcpServers") {
+        if !servers.is_empty() {
+            claude_json["mcpServers"] = Value::Object(servers.clone());
+        }
     }
 
     // Back up the existing file before modifying it

--- a/src-tauri/src/services/copilot_config.rs
+++ b/src-tauri/src/services/copilot_config.rs
@@ -204,6 +204,11 @@ pub fn write_copilot_config(path: &Path, mcps: &[McpTuple]) -> Result<()> {
         CopilotMcpConfig::default()
     };
 
+    // Skip overwrite when DB has no MCPs — preserves externally-managed configs
+    if mcps.is_empty() {
+        return Ok(());
+    }
+
     // Back up the existing file before modifying it
     backup_config_file(path)?;
 

--- a/src-tauri/src/services/cursor_config.rs
+++ b/src-tauri/src/services/cursor_config.rs
@@ -185,6 +185,11 @@ pub fn write_cursor_config(path: &Path, mcps: &[McpTuple]) -> Result<()> {
         CursorMcpConfig::default()
     };
 
+    // Skip overwrite when DB has no MCPs — preserves externally-managed configs
+    if mcps.is_empty() {
+        return Ok(());
+    }
+
     // Back up the existing file before modifying it
     backup_config_file(path)?;
 

--- a/src-tauri/src/services/gemini_config.rs
+++ b/src-tauri/src/services/gemini_config.rs
@@ -206,6 +206,11 @@ pub fn write_gemini_config(path: &Path, mcps: &[McpTuple]) -> Result<()> {
         GeminiSettingsConfig::default()
     };
 
+    // Skip overwrite when DB has no MCPs — preserves externally-managed configs
+    if mcps.is_empty() {
+        return Ok(());
+    }
+
     // Back up the existing file before modifying it
     backup_settings_file(path)?;
 

--- a/src-tauri/src/services/opencode_config.rs
+++ b/src-tauri/src/services/opencode_config.rs
@@ -248,9 +248,12 @@ pub fn write_opencode_global_config(config_path: &Path, mcps: &[McpTuple]) -> Re
     };
 
     // Build MCP object
+    // Skip overwrite when DB has no MCPs — preserves externally-managed configs
     let mcp_config = generate_opencode_mcp_config(mcps);
-    if let Some(mcp) = mcp_config.get("mcp") {
-        config["mcp"] = mcp.clone();
+    if let Some(Value::Object(mcp)) = mcp_config.get("mcp") {
+        if !mcp.is_empty() {
+            config["mcp"] = Value::Object(mcp.clone());
+        }
     }
 
     // Back up the existing file before modifying it
@@ -284,9 +287,12 @@ pub fn write_opencode_project_config(project_path: &Path, mcps: &[McpTuple]) -> 
     };
 
     // Build MCP object
+    // Skip overwrite when DB has no MCPs — preserves externally-managed configs
     let mcp_config = generate_opencode_mcp_config(mcps);
-    if let Some(mcp) = mcp_config.get("mcp") {
-        config["mcp"] = mcp.clone();
+    if let Some(Value::Object(mcp)) = mcp_config.get("mcp") {
+        if !mcp.is_empty() {
+            config["mcp"] = Value::Object(mcp.clone());
+        }
     }
 
     // Back up the existing file before modifying it

--- a/src-tauri/src/services/scanner.rs
+++ b/src-tauri/src/services/scanner.rs
@@ -388,6 +388,54 @@ fn assign_mcp_to_project(
     Ok(())
 }
 
+/// Import MCPs from a project's .mcp.json into the database.
+/// Called when a project is added so externally-configured servers show up in the UI.
+pub fn import_mcps_from_project_mcp_json(
+    db: &Database,
+    project_id: i64,
+    project_path: &str,
+) -> Result<usize> {
+    let path = std::path::PathBuf::from(project_path);
+    let mcp_file = path.join(".mcp.json");
+
+    if !mcp_file.exists() {
+        return Ok(0);
+    }
+
+    let mcps = match config_parser::parse_mcp_file(&mcp_file) {
+        Ok(m) => m,
+        Err(e) => {
+            log::warn!("Failed to parse .mcp.json at {}: {}", mcp_file.display(), e);
+            return Ok(0);
+        }
+    };
+
+    let mut count = 0;
+    for mcp in &mcps {
+        let mcp_id = get_or_create_mcp(
+            db,
+            &mcp.name,
+            &mcp.mcp_type,
+            mcp.command.as_deref(),
+            mcp.args.as_ref(),
+            mcp.url.as_deref(),
+            mcp.headers.as_ref(),
+            mcp.env.as_ref(),
+            project_path,
+        )?;
+
+        assign_mcp_to_project(db, project_id, mcp_id, true)?;
+        count += 1;
+    }
+
+    log::info!(
+        "Imported {} MCPs from .mcp.json for project {}",
+        count,
+        project_path
+    );
+    Ok(count)
+}
+
 /// Scan plugins/marketplaces directory for MCPs
 pub fn scan_plugins(db: &Database) -> Result<usize> {
     let paths = get_claude_paths()?;


### PR DESCRIPTION
## Summary

- **Fixes #191 (reopened)** — Sync Config was still overwriting `.mcp.json`, `claude.json`, `opencode.json`, and other editor configs with empty `{}` when a project had no MCPs in the app's database
- **Imports MCPs from `.mcp.json` on project add** — externally-configured servers now appear in the UI instead of showing an empty project
- **Adds missing Tauri commands** — `open_folder` and `update_project_editor_type` were invoked by the frontend but never implemented

## Root cause

The previous fix (3064d5f) only guarded `write_project_config()` and `write_global_config()`, but missed `write_project_to_claude_json()` and all other editor config writers (OpenCode, Copilot, Cursor, Gemini, Codex). Additionally, `.mcp.json` was never read/imported when adding a project — the app only checked if the file *existed* but never parsed it.

## Changes

| File | Change |
|------|--------|
| `config_writer.rs` | Guard `write_project_to_claude_json` against empty overwrite |
| `opencode_config.rs` | Guard both global and project writers |
| `copilot_config.rs` | Early return when mcps empty |
| `cursor_config.rs` | Early return when mcps empty |
| `gemini_config.rs` | Early return when mcps empty |
| `codex_config.rs` | Early return when mcps empty |
| `scanner.rs` | New `import_mcps_from_project_mcp_json` function |
| `projects.rs` | Import MCPs on add, fix `.mcp.json` path, add `open_folder` + `update_project_editor_type` commands |
| `lib.rs` | Register new commands |

## Test plan

- [x] `cargo check` — 0 errors
- [x] `cargo test` — 1991 tests pass (including updated preservation test)
- [ ] Manual: add a project with an existing `.mcp.json` → servers should appear in the UI
- [ ] Manual: click Sync Config on a project with no app-managed MCPs → `.mcp.json` should be preserved
- [ ] Manual: verify `open_folder` and editor type switching work in project dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)