### PR TITLE
feat(settings): use model aliases + 1M context toggle + custom ID

### DIFF
--- a/src/lib/components/claude-settings/ModelConfigEditor.svelte
+++ b/src/lib/components/claude-settings/ModelConfigEditor.svelte
@@ -15,7 +15,22 @@
 
 	let { settings, onsave }: Props = $props();
 
-	let model = $state(settings.model ?? '');
+	// Parse a saved model value into (base, has1m) so the UI can split the [1m] suffix
+	// from the underlying ID. The suffix is documented as a Claude Code extension that
+	// is stripped before the request reaches the provider.
+	function splitModelValue(raw: string | undefined): { base: string; has1m: boolean } {
+		if (!raw) return { base: '', has1m: false };
+		if (raw.endsWith('[1m]')) return { base: raw.slice(0, -'[1m]'.length), has1m: true };
+		return { base: raw, has1m: false };
+	}
+
+	const initial = splitModelValue(settings.model);
+	const knownValues = CLAUDE_MODELS.map((m) => m.value) as readonly string[];
+	const initialIsKnown = !initial.base || knownValues.includes(initial.base);
+
+	let modelChoice = $state<string>(initialIsKnown ? initial.base : '__custom__');
+	let customModel = $state<string>(initialIsKnown ? '' : initial.base);
+	let use1mContext = $state<boolean>(initial.has1m);
 	let availableModels = $state<string[]>([...settings.availableModels]);
 	let outputStyle = $state(settings.outputStyle ?? '');
 	let language = $state(settings.language ?? '');
@@ -23,17 +38,47 @@
 
 	// Reset local state when settings prop changes
 	$effect(() => {
-		model = settings.model ?? '';
+		const next = splitModelValue(settings.model);
+		const known = !next.base || knownValues.includes(next.base);
+		modelChoice = known ? next.base : '__custom__';
+		customModel = known ? '' : next.base;
+		use1mContext = next.has1m;
 		availableModels = [...settings.availableModels];
 		outputStyle = settings.outputStyle ?? '';
 		language = settings.language ?? '';
 		alwaysThinkingEnabled = settings.alwaysThinkingEnabled;
 	});
 
+	// Resolve the effective model string from the dropdown + custom field + 1m toggle.
+	// Returns undefined when nothing is selected so the setting is omitted entirely.
+	function resolveModelValue(): string | undefined {
+		const base = modelChoice === '__custom__' ? customModel.trim() : modelChoice;
+		if (!base) return undefined;
+		if (!use1mContext) return base;
+		// Don't double-append [1m] if the user typed it themselves
+		return base.endsWith('[1m]') ? base : `${base}[1m]`;
+	}
+
+	// 1M context only applies to models that support it. Built-in entries declare this
+	// via supports1m; custom IDs are assumed eligible (we can't verify) and the user
+	// keeps responsibility for typing a valid ID.
+	function selectionSupports1m(): boolean {
+		if (modelChoice === '__custom__') return customModel.trim().length > 0;
+		const entry = CLAUDE_MODELS.find((m) => m.value === modelChoice);
+		return entry?.supports1m ?? false;
+	}
+
+	// Auto-clear the 1M flag if the user picks a model that doesn't support it
+	$effect(() => {
+		if (!selectionSupports1m() && use1mContext) {
+			use1mContext = false;
+		}
+	});
+
 	function handleSave() {
 		onsave({
 			...settings,
-			model: model || undefined,
+			model: resolveModelValue(),
 			availableModels,
 			outputStyle: outputStyle || undefined,
 			language: language || undefined,
@@ -74,14 +119,61 @@
 			</label>
 			<select
 				id="model-select"
-				bind:value={model}
+				bind:value={modelChoice}
 				class="input text-sm w-full"
 			>
 				<option value="">Not set (use default)</option>
 				{#each CLAUDE_MODELS as m}
 					<option value={m.value}>{m.label} — {m.description}</option>
 				{/each}
+				<option value="__custom__">Other (custom model ID)…</option>
 			</select>
+			{#if modelChoice === '__custom__'}
+				<input
+					type="text"
+					bind:value={customModel}
+					placeholder="e.g. claude-opus-4-7 or arn:aws:bedrock:…"
+					class="input text-sm w-full mt-2"
+					aria-label="Custom model ID"
+				/>
+				<p class="text-xs text-gray-500 dark:text-gray-400 mt-1">
+					Enter any model ID, alias, or provider-specific identifier. Append <code>[1m]</code>
+					yourself if not using the toggle below.
+				</p>
+			{/if}
+			<p class="text-xs text-gray-500 dark:text-gray-400 mt-1">
+				Aliases like <code>opus</code>, <code>sonnet</code>, <code>haiku</code> auto-resolve
+				to the latest version. See
+				<a
+					href="https://code.claude.com/docs/en/model-config#available-models"
+					target="_blank"
+					rel="noopener"
+					class="underline hover:text-primary-600">model configuration docs</a>.
+			</p>
+		</div>
+
+		<!-- 1M Context Window -->
+		<div>
+			<label class="flex items-center gap-2 cursor-pointer">
+				<input
+					type="checkbox"
+					bind:checked={use1mContext}
+					disabled={!selectionSupports1m()}
+					class="rounded border-gray-300 dark:border-gray-600"
+				/>
+				<span class="text-sm font-medium text-gray-700 dark:text-gray-300">
+					Use 1M token context window
+				</span>
+			</label>
+			<p class="text-xs text-gray-500 dark:text-gray-400 mt-1 ml-6">
+				Appends the <code>[1m]</code> suffix to the model ID. Supported on Opus and Sonnet
+				(not Haiku). Standard pricing — no premium beyond 200K tokens.
+				<a
+					href="https://code.claude.com/docs/en/model-config#extended-context"
+					target="_blank"
+					rel="noopener"
+					class="underline hover:text-primary-600">Docs</a>.
+			</p>
 		</div>
 
 		<!-- Available Models -->

--- a/src/lib/types/claudeSettings.ts
+++ b/src/lib/types/claudeSettings.ts
@@ -118,21 +118,39 @@ export interface AllClaudeSettings {
 	local?: ClaudeSettings;
 }
 
+// Model aliases auto-resolve to the latest version Claude Code supports.
+// See https://code.claude.com/docs/en/model-config#available-models
+// The [1m] suffix is documented at https://code.claude.com/docs/en/model-config#extended-context
 export const CLAUDE_MODELS = [
 	{
-		value: 'claude-sonnet-4-5-20250929',
-		label: 'Claude Sonnet 4.5',
-		description: 'Best balance of speed and intelligence'
+		value: 'opus',
+		label: 'Opus (latest)',
+		description: 'Most capable model for complex reasoning',
+		supports1m: true
 	},
 	{
-		value: 'claude-opus-4-6',
-		label: 'Claude Opus 4.6',
-		description: 'Most capable model for complex tasks'
+		value: 'sonnet',
+		label: 'Sonnet (latest)',
+		description: 'Balanced speed and intelligence for daily coding',
+		supports1m: true
 	},
 	{
-		value: 'claude-haiku-4-5-20251001',
-		label: 'Claude Haiku 4.5',
-		description: 'Fastest model for simple tasks'
+		value: 'haiku',
+		label: 'Haiku (latest)',
+		description: 'Fastest model for simple tasks',
+		supports1m: false
+	},
+	{
+		value: 'opusplan',
+		label: 'Opus + Plan (opusplan)',
+		description: 'Opus during plan mode, Sonnet for execution',
+		supports1m: true
+	},
+	{
+		value: 'best',
+		label: 'Best available',
+		description: 'Most capable model available (currently equivalent to Opus)',
+		supports1m: true
 	}
 ] as const;
 

--- a/src/tests/components/claude-settings.test.ts
+++ b/src/tests/components/claude-settings.test.ts
@@ -125,12 +125,21 @@ describe('AttributionEditor Component', () => {
 	});
 });
 
-describe('Extended Context Types', () => {
-	it('should include extended context models in CLAUDE_MODELS', async () => {
+describe('Model aliases (CLAUDE_MODELS)', () => {
+	it('should expose the core Anthropic aliases', async () => {
 		const { CLAUDE_MODELS } = await import('$lib/types');
 		const values = CLAUDE_MODELS.map(m => m.value);
-		expect(values).toContain('claude-sonnet-4-5-20250929');
-		expect(values).toContain('claude-opus-4-6');
+		expect(values).toContain('opus');
+		expect(values).toContain('sonnet');
+		expect(values).toContain('haiku');
+	});
+
+	it('should mark Opus and Sonnet as 1M-capable, Haiku as not', async () => {
+		const { CLAUDE_MODELS } = await import('$lib/types');
+		const byValue = Object.fromEntries(CLAUDE_MODELS.map(m => [m.value, m]));
+		expect(byValue.opus.supports1m).toBe(true);
+		expect(byValue.sonnet.supports1m).toBe(true);
+		expect(byValue.haiku.supports1m).toBe(false);
 	});
 
 	it('should include extended context shortcuts in AVAILABLE_MODEL_SHORTCUTS', async () => {


### PR DESCRIPTION
Closes #212.

## Summary

The Default Model dropdown in **Settings → Models** shipped hardcoded full model IDs (`claude-sonnet-4-5-20250929`, `claude-opus-4-6`, `claude-haiku-4-5-20251001`) that go stale every time Anthropic ships a new model. This PR switches to **model aliases** — Claude Code's documented mechanism for forward-compatibility — and adds the missing **1M context window** toggle plus a **custom model ID** escape hatch.

## Why aliases

Per the [Claude Code model-config docs](https://code.claude.com/docs/en/model-config#available-models):

> Aliases point to the recommended version for your provider and update over time.

Aliases (`opus`, `sonnet`, `haiku`, `opusplan`, `best`) auto-resolve on the provider side, so the tool-manager no longer needs a release every time a new model lands. There's no authoritative client-side way to list available models without an `ANTHROPIC_API_KEY` (subscription users may not have one), so aliases are the most robust choice.

## Changes

**`src/lib/types/claudeSettings.ts`**
- `CLAUDE_MODELS` now lists aliases (`opus`, `sonnet`, `haiku`, `opusplan`, `best`) with a `supports1m: boolean` flag.

**`src/lib/components/claude-settings/ModelConfigEditor.svelte`**
- Adds an **"Other (custom model ID)…"** option that reveals a free-text input. Accepts any string — full model name, Bedrock ARN, Vertex version name, Foundry deployment name.
- Adds a **"Use 1M token context window"** checkbox that appends the documented `[1m]` suffix to the saved model ID. Auto-disables when a non-1M model (Haiku) is selected. Round-trips correctly through `settings.model`.
- Inline help text links to the official Claude Code docs.

**`src/tests/components/claude-settings.test.ts`**
- Updates the previously-mislabeled "Extended Context Types" describe block to verify the alias contract and the `supports1m` flag per model.

## Test plan

- [x] `npm test -- --run` — all 1565 tests pass
- [x] `npm test -- --run src/tests/components/claude-settings.test.ts src/tests/components/model-overrides.test.ts` — 24/24 pass
- [x] `npm run check` — no new errors introduced (75 pre-existing errors in unrelated files like `ContainerTerminal.svelte`, `keybindingsLibrary.test.ts`, none touched by this PR)
- [ ] Manual: set Default Model to `opus`, check 1M box → saved as `opus[1m]`
- [ ] Manual: switch to Haiku → 1M checkbox auto-disables and clears
- [ ] Manual: select "Other (custom)" → enter `arn:aws:bedrock:…` → saves verbatim
- [ ] Manual: load existing `settings.model: "claude-opus-4-7[1m]"` → custom field shows `claude-opus-4-7`, 1M box checked

## Notes

- `AVAILABLE_MODEL_SHORTCUTS` (the "Available Models" multi-select) is unchanged — it already used aliases.
- `SubAgentForm.svelte` model picker is unchanged — it already used aliases.
- `model-overrides.test.ts` is unchanged — its fixtures use full IDs as map keys to test the override mechanism, which is still correct semantically.
