### PR TITLE
fix(types): close 22 svelte-check errors via additive type updates (#214 PR1)

### DIFF
--- a/src/lib/components/shared/Badge.svelte
+++ b/src/lib/components/shared/Badge.svelte
@@ -2,7 +2,7 @@
 	import type { Snippet, Component } from 'svelte';
 
 	type Props = {
-		variant?: 'default' | 'success' | 'warning' | 'error' | 'system' | 'auto';
+		variant?: 'default' | 'success' | 'warning' | 'error' | 'system' | 'auto' | 'info';
 		title?: string;
 		icon?: Component<any>;
 		children?: Snippet;
@@ -16,7 +16,8 @@
 		warning: 'bg-amber-100 text-amber-700 dark:bg-amber-900/50 dark:text-amber-300',
 		error: 'bg-red-100 text-red-700 dark:bg-red-900/50 dark:text-red-300',
 		system: 'bg-indigo-100 text-indigo-700 dark:bg-indigo-900/50 dark:text-indigo-300',
-		auto: 'bg-cyan-100 text-cyan-700 dark:bg-cyan-900/50 dark:text-cyan-300'
+		auto: 'bg-cyan-100 text-cyan-700 dark:bg-cyan-900/50 dark:text-cyan-300',
+		info: 'bg-blue-100 text-blue-700 dark:bg-blue-900/50 dark:text-blue-300'
 	};
 </script>
 

--- a/src/lib/types/claudeSettings.ts
+++ b/src/lib/types/claudeSettings.ts
@@ -9,6 +9,12 @@ export interface SandboxNetworkSettings {
 	socksProxyPort?: number;
 }
 
+export interface SandboxFilesystemSettings {
+	allowRead?: string[];
+	denyRead?: string[];
+	allowUnixSockets?: string[];
+}
+
 export interface SandboxSettings {
 	enabled?: boolean;
 	autoAllowBashIfSandboxed?: boolean;
@@ -100,6 +106,13 @@ export interface ClaudeSettings {
 	enableAllProjectMcpServers?: boolean;
 	enabledMcpjsonServers?: string[];
 	disabledMcpjsonServers?: string[];
+	// Auto Mode
+	disableAutoMode?: boolean;
+	autoModeEnvironment?: string;
+	autoModeAllow?: string;
+	autoModeSoftDeny?: string;
+	// Model Overrides — map Anthropic model IDs to provider-specific IDs (Bedrock/Vertex/Foundry)
+	modelOverrides?: Record<string, string>;
 	// Managed-only keys (from managed-settings.json, read-only)
 	allowManagedHooksOnly?: boolean;
 	allowManagedPermissionRulesOnly?: boolean;

--- a/src/lib/types/skill.ts
+++ b/src/lib/types/skill.ts
@@ -1,3 +1,8 @@
+// Discriminator used by the markdown parser to distinguish slash-command markdown
+// (`.claude/commands/`) from agent-skill markdown (`.claude/skills/`). The two
+// formats share frontmatter but route to different stores.
+export type SkillType = 'skill' | 'command';
+
 export interface Skill {
 	id: number;
 	name: string;
@@ -22,6 +27,7 @@ export interface CreateSkillRequest {
 	model?: string;
 	disableModelInvocation?: boolean;
 	tags?: string[];
+	skillType?: SkillType;
 }
 
 export interface ProjectSkill {

--- a/src/tests/components/spinnerverbs.test.ts
+++ b/src/tests/components/spinnerverbs.test.ts
@@ -36,7 +36,14 @@ describe('SpinnerVerbForm Component', () => {
 		const { default: SpinnerVerbForm } = await import('$lib/components/spinnerverbs/SpinnerVerbForm.svelte');
 		render(SpinnerVerbForm, {
 			props: {
-				initialValues: { id: 1, verb: 'Pondering', isEnabled: true, sortOrder: 0 },
+				initialValues: {
+					id: 1,
+					verb: 'Pondering',
+					isEnabled: true,
+					displayOrder: 0,
+					createdAt: '2025-01-01T00:00:00Z',
+					updatedAt: '2025-01-01T00:00:00Z'
+				},
 				onSubmit: vi.fn(),
 				onCancel: vi.fn()
 			}


### PR DESCRIPTION
First of the cleanups proposed in #214. Purely additive field/type changes — no behavior changes. Brings `npm run check` from **75 → 53 errors** (closes 22).

## What was wrong

Components and tests were reading fields and types that `$lib/types` didn't expose. The reads were correct (data round-trips through `settings.json` and Tauri), but the type contracts had drifted, so the errors were piling up silently.

## Changes

| File | Why |
|---|---|
| `claudeSettings.ts` | Add `disableAutoMode`, `autoModeEnvironment`, `autoModeAllow`, `autoModeSoftDeny` (read by `AutoModeEditor`, `SettingsAutoModeTab`); `modelOverrides` (read by `ModelOverridesEditor` for Bedrock/Vertex/Foundry ID mapping); new `SandboxFilesystemSettings` interface (`allowRead`/`denyRead`/`allowUnixSockets`) covering what `SandboxFilesystemEditor` already accepts. |
| `skill.ts` | Export `SkillType = 'skill' \| 'command'` (used by `markdownParser` to discriminate slash-command vs. agent-skill frontmatter); add optional `skillType` to `CreateSkillRequest`. |
| `Badge.svelte` | Add `info` variant (blue) — `ProjectCard` already passes it for the Claude editor badge. |
| `spinnerverbs.test.ts` | Fixture had `sortOrder` (a typo — that field doesn't exist anywhere else, including the Rust `SpinnerVerb` struct which uses `display_order`). Replaced with the real `displayOrder` field plus the required `createdAt` / `updatedAt` timestamps so the fixture matches the existing `SpinnerVerb` contract. |

## Decision: fix the test, don't add `sortOrder`

#214's classification suggested adding `sortOrder` to `SpinnerVerb` as the additive fix. I tried that first — it surfaced a deeper error (the fixture was *also* missing the required `displayOrder` / `createdAt` / `updatedAt` fields), so the test still didn't typecheck. Adding a phantom field that nothing else in the repo or in `src-tauri` reads would have just papered over a fixture typo. Fixing the fixture is one line, lower risk, and removes the false-signal field.

## Maps to #214 groups

Closes groups **C** (auto-mode, 13 errors), **F** (modelOverrides, 3), **G** (SkillType / skillType, 3), **I** (Badge info, 1), **J** (SpinnerVerb fixture, 1), **L** (SandboxFilesystemSettings, 1) = **22 total**.

The remaining 53 errors fall into #214's groups A, B, D, E, H, K, M — those are the targets for follow-up PRs (heavier; PR 2 onward).

## Test plan

- [x] `npm run check` — 53 errors (down from 75 on `main`)
- [x] `npx vitest run` — 1565/1565 tests pass
- [x] Verified zero NEW errors (set diff: only deletions, no additions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)