### PR TITLE
fix(types): close 26 svelte-check errors via SubAgent type drift (#214 PR2)

### DIFF
--- a/src/lib/types/subagent.ts
+++ b/src/lib/types/subagent.ts
@@ -8,6 +8,15 @@ export interface SubAgent {
 	permissionMode?: string;
 	skills?: string[];
 	tags?: string[];
+	disallowedTools?: string[];
+	maxTurns?: number;
+	memory?: string;
+	background?: boolean;
+	effort?: string;
+	isolation?: string;
+	hooks?: string;
+	mcpServers?: string;
+	initialPrompt?: string;
 	source: string;
 	sourcePath?: string;
 	isFavorite: boolean;
@@ -24,6 +33,15 @@ export interface CreateSubAgentRequest {
 	permissionMode?: string;
 	skills?: string[];
 	tags?: string[];
+	disallowedTools?: string[];
+	maxTurns?: number;
+	memory?: string;
+	background?: boolean;
+	effort?: string;
+	isolation?: string;
+	hooks?: string;
+	mcpServers?: string;
+	initialPrompt?: string;
 }
 
 export interface ProjectSubAgent {

--- a/src/lib/utils/markdownParser.ts
+++ b/src/lib/utils/markdownParser.ts
@@ -50,6 +50,13 @@ export interface ParsedSubAgent {
 	permissionMode?: string;
 	skills?: string[];
 	tags?: string[];
+	disallowedTools?: string[];
+	maxTurns?: number;
+	memory?: string;
+	background?: boolean;
+	effort?: string;
+	isolation?: string;
+	initialPrompt?: string;
 }
 
 export interface ParseResult<T> {


### PR DESCRIPTION
Second of the cleanups proposed in #214 (Group A). Purely additive field updates — no behavior changes. Brings `npm run check` from **53 → 27 errors** (closes 26).

## What was wrong

`SubAgentForm.svelte` reads and writes nine fields that the type contracts never exposed. The reads/writes are correct — the data round-trips through `settings.json`, the Rust `subagents` table (20 columns, all present in `subagents.rs` and `subagent_writer.rs`), and Tauri — but `$lib/types` and `markdownParser` had drifted, so the errors piled up silently.

## Changes

| File | Why |
|---|---|
| `subagent.ts` | Add `disallowedTools`, `maxTurns`, `memory`, `background`, `effort`, `isolation`, `hooks`, `mcpServers`, `initialPrompt` to both `SubAgent` (read via `Partial<SubAgent>` as the form's `initialValues`) and `CreateSubAgentRequest` (the object `handleSubmit` builds). Types match the Rust struct: `string[]` for `disallowedTools`, numeric `maxTurns`, boolean `background`, the rest strings. |
| `markdownParser.ts` | Add the seven fields `applyParsedSubAgent` assigns to `ParsedSubAgent`. `hooks`/`mcpServers` excluded — the paste/import path doesn't touch them. |

## Maps to #214 groups

Closes group **A** (SubAgent / ParsedSubAgent type drift, 26 errors).

The remaining 27 errors fall into #214's groups **B** (containers, 10), **D** (lucide icon types, 7), **E** (keybindings `"Input"` context, 6), **H** (sessions store rename, 2), **K** (Tauri InvokeArgs mock, 1), **M** (subagents `selectedProject`, 1) — targets for follow-up PRs.

## Test plan

- [x] `npm run check` — 27 errors (down from 53 on `main`)
- [x] `npx vitest run` — 1565/1565 tests pass
- [x] Verified zero NEW errors — the remaining 27 all pre-existing, each maps to one of #214's other groups

🤖 Generated with [Claude Code](https://claude.com/claude-code)