### PR TITLE
fix(types): close 3 svelte-check errors — sessions prop + invoke mock (#214 PR4)

### DIFF
--- a/src/routes/sessions/+page.svelte
+++ b/src/routes/sessions/+page.svelte
@@ -139,7 +139,6 @@
 		{:else if sessionStore.sessionDetail}
 			<SessionDetailPanel
 				detail={sessionStore.sessionDetail}
-				sessionSummary={sessionStore.selectedSessionSummary}
 				onClose={() => sessionStore.clearSession()}
 			/>
 		{/if}

--- a/src/tests/helpers/invokeMock.ts
+++ b/src/tests/helpers/invokeMock.ts
@@ -1,5 +1,6 @@
 import { vi } from 'vitest';
 import { invoke } from '@tauri-apps/api/core';
+import type { InvokeArgs } from '@tauri-apps/api/core';
 
 /**
  * Set up command-routing mock for Tauri invoke.
@@ -33,7 +34,7 @@ export function mockInvokeResponses(responses: Record<string, unknown>): void {
 export function mockInvokeHandler(
 	handler: (cmd: string, args?: Record<string, unknown>) => unknown
 ): void {
-	vi.mocked(invoke).mockImplementation(async (cmd: string, args?: Record<string, unknown>) => {
-		return handler(cmd, args);
+	vi.mocked(invoke).mockImplementation(async (cmd: string, args?: InvokeArgs) => {
+		return handler(cmd, args as Record<string, unknown> | undefined);
 	});
 }


### PR DESCRIPTION
Part of the #214 cleanup. Brings `npm run check` from **53 → 50 errors** (closes 3). Scoped to the two genuinely mechanical fixes from #214's proposed PR4 — groups **E** and **M** turned out to need real investigation (see below).

## Changes

| Group | File | Fix |
|---|---|---|
| **H** | `routes/sessions/+page.svelte` | Passed `sessionSummary={sessionStore.selectedSessionSummary}` to `SessionDetailPanel`. Neither side exists anymore — `SessionStoreState` has no `selectedSessionSummary`, and `SessionDetailPanel`'s `Props` is `{ detail, onClose }`. The prop was already dead; removed the line. |
| **K** | `tests/helpers/invokeMock.ts` | Typed the `invoke` mock implementation's `args` as `Record<string, unknown>`. Tauri's `invoke` is `(cmd, args?: InvokeArgs, …)` and `InvokeArgs` is wider (e.g. `number[]`), so the narrower callback param made the mock unassignable. Widened to `InvokeArgs`, cast at the boundary where it's handed to the ergonomic `handler`. |

## Deferred from #214's PR4 grouping

#214 grouped E + H + K + M as "test-fixture cleanup, low risk." H and K are — E and M aren't:

- **Group E** (keybindings `"Input"` context, 6 errors) — the tests pass at runtime (31/31) but reference `'Input'`, which is in neither `KEYBINDING_CONTEXTS` nor `KEYBINDING_ACTIONS`; they only pass via cross-test override state leakage. Adding `'Input'` to the `KeybindingContext` union would be a phantom-value behavior change; rewriting the tests needs care around those state dependencies. Worth its own PR.
- **Group M** (`AgentMemoryPanel` `selectedProject`, 1 error) — a latent **runtime bug**, not type drift. `projectsStore` (`ProjectsState`) has no project-selection concept at all, so `projectsStore.selectedProject?.path ?? null` always evaluates to `null` — the panel's project-scope agent memory silently never receives a path. Fixing it means deciding how the panel learns the current project (prop vs. route param) — a design call, not a fixture edit.

## Test plan

- [x] `npm run check` — 50 errors (down from 53 on `main`)
- [x] `npx vitest run` — sessionStore + invokeMock consumers pass
- [x] Zero new errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)