### PR TITLE
chore(ci): pin dtolnay/rust-toolchain to SHA

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -100,7 +100,7 @@ jobs:
           cache: npm
 
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # @stable as of 2026-03-27
         with:
           targets: ${{ matrix.target }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,7 +90,7 @@ jobs:
           cache: npm
 
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # @stable as of 2026-03-27
         with:
           targets: ${{ matrix.target }}
 

--- a/.github/workflows/rust-tests.yml
+++ b/.github/workflows/rust-tests.yml
@@ -29,7 +29,7 @@ jobs:
           sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
 
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # @stable as of 2026-03-27
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -81,7 +81,7 @@ jobs:
         run: npm run build
 
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # @stable as of 2026-03-27
         with:
           components: clippy
 
@@ -102,7 +102,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # @stable as of 2026-03-27
         with:
           components: rustfmt
 


### PR DESCRIPTION
Replaces all 5 `@stable` refs across `build.yml`, `release.yml`, and `rust-tests.yml` with a SHA pin to `29eef336d9b2848a0b548edc03f92a220660cdb8` (`@stable` head as of 2026-03-27).

## Why

`@stable` is a floating ref — any regression dtolnay ships breaks every PR in flight at once, and we have no signal until a build fails. Pinning to SHA freezes our action surface so toolchain changes become explicit lockfile-style updates we choose to take.

## What this does NOT fix

The recent macOS `cargo metadata` → `rustup-init` flake hitting several open PRs (#226, #228, #231, #232, #234) is **runner-side**, not action-side: this SHA was already what `@stable` resolved to before and during the flake window. Reruns of failed jobs are passing on the same SHA, confirming it's transient runner state, not the action.

So this PR is **hygiene, not the fix for the current symptom**. If the flake persists we'll need to either:
- work around in the workflow (retry on the rust-toolchain step), or
- switch to `actions-rust-lang/setup-rust-toolchain`

## Updating later

When we want a newer toolchain or action behavior, bump the SHA and update the trailing comment. Worth pointing Dependabot at `github-actions` to get auto-proposed bumps for these.

🤖 Generated with [Claude Code](https://claude.com/claude-code)